### PR TITLE
#4: Fix broken read-only tools for defects, users, and configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `list_defects`: Corrected API call signature (status as single value, not array) and removed unsupported severity filter
+- `list_users`, `get_user`: Switched to direct HTTP calls (qaseio SDK doesn't expose Users API)
+- `list_shared_parameters`, `get_shared_parameter`: Switched to direct HTTP calls (qaseio SDK doesn't expose Shared Parameters API)
+- `list_system_fields`: Switched to direct HTTP calls (qaseio SDK doesn't expose System Fields API)
+- `list_configurations`: Switched to direct HTTP calls (qaseio SDK doesn't expose Configurations API)
+
 ## [1.0.0] - 2025-10-08
 
 ### Added

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -5,9 +5,12 @@
  * - Token-based authentication
  * - Custom enterprise domains
  * - Environment-based configuration
+ *
+ * Also provides direct API call helper for endpoints not exposed by the SDK.
  */
 
 import { QaseApi } from 'qaseio';
+import axios, { AxiosRequestConfig } from 'axios';
 
 /**
  * Configuration for the Qase API client
@@ -76,6 +79,34 @@ export function getApiClient(): QaseApi {
  */
 export function resetClientInstance(): void {
   clientInstance = null;
+}
+
+/**
+ * Make a direct API call to Qase API for endpoints not exposed by the SDK.
+ * Use this for: /user, /shared_parameter, /configuration, /system_field
+ *
+ * @param path - API path (e.g., '/v1/user' or '/v1/user/123')
+ * @param options - Optional axios request config (for query params, etc.)
+ * @returns Promise with the API response data
+ */
+export async function apiRequest<T = any>(
+  path: string,
+  options: AxiosRequestConfig = {},
+): Promise<T> {
+  const config = getConfig();
+
+  const response = await axios({
+    method: options.method || 'GET',
+    url: `${config.host}${path}`,
+    headers: {
+      Token: config.token,
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+    ...options,
+  });
+
+  return response.data;
 }
 
 // Re-export types from qaseio for convenience

--- a/src/operations/defects.ts
+++ b/src/operations/defects.ts
@@ -35,13 +35,28 @@ const DefectStatusEnum = z.enum(['open', 'in_progress', 'resolved', 'invalid']);
 
 /**
  * Schema for listing defects
+ * API: GET /v1/defect/{code}
+ * https://developers.qase.io/reference/get-defects
+ *
+ * The Qase API only supports filtering by a single status value.
+ * Severity filtering is not supported by the API.
  */
 const ListDefectsSchema = z.object({
   code: ProjectCodeSchema,
-  status: z.array(DefectStatusEnum).optional().describe('Filter by status'),
-  severity: z.array(DefectSeverityEnum).optional().describe('Filter by severity'),
-  limit: z.number().int().positive().max(100).optional().describe('Maximum number of items'),
-  offset: z.number().int().nonnegative().optional().describe('Number of items to skip'),
+  status: DefectStatusEnum.optional().describe('Filter by status'),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(100)
+    .optional()
+    .describe('Maximum number of items (default: 10)'),
+  offset: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .describe('Number of items to skip (default: 0)'),
 });
 
 /**
@@ -109,14 +124,14 @@ const UpdateDefectStatusSchema = z.object({
 
 /**
  * List all defects in a project
+ * API: GET /v1/defect/{code}
+ * https://developers.qase.io/reference/get-defects
  */
 async function listDefects(args: z.infer<typeof ListDefectsSchema>) {
   const client = getApiClient();
-  const { code, status, severity, limit, offset } = args;
+  const { code, status, limit, offset } = args;
 
-  const result = await toResultAsync(
-    client.defects.getDefects(code, { status, severity } as any, limit, offset),
-  );
+  const result = await toResultAsync(client.defects.getDefects(code, status, limit, offset));
 
   return result.match(
     (response) => response.data.result,

--- a/src/operations/system-fields.ts
+++ b/src/operations/system-fields.ts
@@ -3,12 +3,15 @@
  *
  * Implements all MCP tools for viewing system field configurations in Qase.
  * System fields are built-in fields that can be configured at the account level.
+ *
+ * The qaseio SDK does not expose the System Fields API in QaseApi class,
+ * so we use direct HTTP calls.
+ * https://developers.qase.io/reference/get-system-fields
  */
 
 import { z } from 'zod';
-import { getApiClient } from '../client/index.js';
+import { apiRequest } from '../client/index.js';
 import { toolRegistry } from '../utils/registry.js';
-import { toResultAsync } from '../utils/errors.js';
 
 // ============================================================================
 // SCHEMAS
@@ -16,6 +19,8 @@ import { toResultAsync } from '../utils/errors.js';
 
 /**
  * Schema for listing system fields (no parameters needed)
+ * API: GET /v1/system_field
+ * https://developers.qase.io/reference/get-system-fields
  */
 const ListSystemFieldsSchema = z.object({});
 
@@ -25,18 +30,12 @@ const ListSystemFieldsSchema = z.object({});
 
 /**
  * List all system fields and their configurations
+ * API: GET /v1/system_field
+ * https://developers.qase.io/reference/get-system-fields
  */
 async function listSystemFields(_args: z.infer<typeof ListSystemFieldsSchema>) {
-  const client = getApiClient();
-
-  const result = await toResultAsync((client as any).systemFields.getSystemFields());
-
-  return result.match(
-    (response: any) => response.data.result,
-    (error) => {
-      throw new Error(error);
-    },
-  );
+  const response = await apiRequest<{ status: boolean; result: any }>('/v1/system_field');
+  return response.result;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Fixes #4

The qaseio SDK v2.4.1 doesn't expose several APIs (users, shared parameters, system fields, configurations) and has wrong parameter signature for the defects endpoint.

## Changes

- Added `apiRequest()` helper in `src/client/index.ts` for direct HTTP calls to Qase API endpoints not exposed by the SDK
- Fixed `list_defects`: Corrected API call signature (status as single value, not array) and removed unsupported severity filter
- Fixed `list_users`, `get_user`: Switched to direct HTTP calls
- Fixed `list_shared_parameters`, `get_shared_parameter`: Switched to direct HTTP calls  
- Fixed `list_system_fields`: Switched to direct HTTP calls
- Fixed `list_configurations`: Switched to direct HTTP calls

## Test plan

- [x] All existing unit tests pass
- [x] Manually tested each fixed tool against live Qase API