### PR TITLE
Bugfix search API

### DIFF
--- a/src/operations/search.ts
+++ b/src/operations/search.ts
@@ -68,7 +68,7 @@ async function qqlSearch(args: z.infer<typeof QqlSearchSchema>) {
   const { query, limit, offset } = args;
 
   const result = await toResultAsync(
-    (client as any).search({
+    (client as any).search.search({
       query,
       limit: limit || 10,
       offset: offset || 0,


### PR DESCRIPTION
  ## Summary                                                                                                                                                           
  Fixed QQL search by changing `client.search()` to `client.search.search()` to match the correct qaseio SDK method path.                                              
                                                                                                                                                                       
  ## Changes                                                                                                                                                           
  - `src/operations/search.ts`: Fix search API method call  