### PR TITLE
feat: return tool execution errors with isError flag for LLM recovery

### DIFF
--- a/src/operations/_template.ts
+++ b/src/operations/_template.ts
@@ -17,7 +17,7 @@
 import { z } from 'zod';
 import { getApiClient } from '../client/index.js';
 import { toolRegistry } from '../utils/registry.js';
-import { toResultAsync } from '../utils/errors.js';
+import { toResultAsync, createToolError } from '../utils/errors.js';
 import { PaginationSchema, ProjectCodeSchema, IdSchema } from '../utils/validation.js';
 
 // ============================================================================
@@ -101,7 +101,7 @@ async function listItems(args: z.infer<typeof ListItemsSchema>) {
       entities: response.data.result.entities,
     }),
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'item operation');
     },
   );
 }
@@ -118,7 +118,7 @@ async function getItem(args: z.infer<typeof GetItemSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'item operation');
     },
   );
 }
@@ -135,7 +135,7 @@ async function createItem(args: z.infer<typeof CreateItemSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'item operation');
     },
   );
 }
@@ -152,7 +152,7 @@ async function updateItem(args: z.infer<typeof UpdateItemSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'item operation');
     },
   );
 }
@@ -169,7 +169,7 @@ async function deleteItem(args: z.infer<typeof DeleteItemSchema>) {
   return result.match(
     (response) => ({ success: true, id }),
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'item operation');
     },
   );
 }
@@ -243,9 +243,10 @@ toolRegistry.register({
  *    - Group related operations together
  *
  * 4. Error Handling:
- *    - Let formatApiError() handle error formatting
- *    - Don't catch errors unnecessarily
- *    - Provide context in error messages
+ *    - Use createToolError() to throw errors with helpful suggestions
+ *    - Include context (e.g., 'creating project') for better suggestions
+ *    - Errors are returned with isError: true for LLM recovery
+ *    - Protocol errors (unknown tool) still throw regular Error
  *
  * 5. Type Safety:
  *    - Use z.infer<> for type inference from schemas

--- a/src/operations/attachments.ts
+++ b/src/operations/attachments.ts
@@ -8,7 +8,7 @@
 import { z } from 'zod';
 import { getApiClient } from '../client/index.js';
 import { toolRegistry } from '../utils/registry.js';
-import { toResultAsync } from '../utils/errors.js';
+import { toResultAsync, createToolError } from '../utils/errors.js';
 import { ProjectCodeSchema, HashSchema } from '../utils/validation.js';
 
 // ============================================================================
@@ -64,7 +64,7 @@ async function listAttachments(args: z.infer<typeof ListAttachmentsSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'attachment operation');
     },
   );
 }
@@ -81,7 +81,7 @@ async function getAttachment(args: z.infer<typeof GetAttachmentSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'attachment operation');
     },
   );
 }
@@ -108,7 +108,7 @@ async function uploadAttachment(args: z.infer<typeof UploadAttachmentSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'attachment operation');
     },
   );
 }
@@ -125,7 +125,7 @@ async function deleteAttachment(args: z.infer<typeof DeleteAttachmentSchema>) {
   return result.match(
     (_response) => ({ success: true, hash }),
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'attachment operation');
     },
   );
 }

--- a/src/operations/authors.ts
+++ b/src/operations/authors.ts
@@ -8,7 +8,7 @@
 import { z } from 'zod';
 import { getApiClient } from '../client/index.js';
 import { toolRegistry } from '../utils/registry.js';
-import { toResultAsync } from '../utils/errors.js';
+import { toResultAsync, createToolError } from '../utils/errors.js';
 import { IdSchema } from '../utils/validation.js';
 
 // ============================================================================
@@ -46,7 +46,7 @@ async function listAuthors(args: z.infer<typeof ListAuthorsSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'author operation');
     },
   );
 }
@@ -63,7 +63,7 @@ async function getAuthor(args: z.infer<typeof GetAuthorSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'author operation');
     },
   );
 }

--- a/src/operations/cases.ts
+++ b/src/operations/cases.ts
@@ -8,7 +8,7 @@
 import { z } from 'zod';
 import { getApiClient } from '../client/index.js';
 import { toolRegistry } from '../utils/registry.js';
-import { toResultAsync } from '../utils/errors.js';
+import { toResultAsync, createToolError } from '../utils/errors.js';
 import { ProjectCodeSchema, IdSchema } from '../utils/validation.js';
 
 // ============================================================================
@@ -170,7 +170,7 @@ async function listCases(args: z.infer<typeof ListCasesSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'case operation');
     },
   );
 }
@@ -187,7 +187,7 @@ async function getCase(args: z.infer<typeof GetCaseSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'case operation');
     },
   );
 }
@@ -204,7 +204,7 @@ async function createCase(args: z.infer<typeof CreateCaseSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'case operation');
     },
   );
 }
@@ -221,7 +221,7 @@ async function updateCase(args: z.infer<typeof UpdateCaseSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'case operation');
     },
   );
 }
@@ -238,7 +238,7 @@ async function deleteCase(args: z.infer<typeof DeleteCaseSchema>) {
   return result.match(
     (_response) => ({ success: true, id }),
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'case operation');
     },
   );
 }
@@ -255,7 +255,7 @@ async function bulkCreateCases(args: z.infer<typeof BulkCreateCasesSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'case operation');
     },
   );
 }
@@ -277,7 +277,7 @@ async function attachExternalIssue(args: z.infer<typeof AttachExternalIssueSchem
   return result.match(
     (_response) => ({ success: true, id, issue_id }),
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'case operation');
     },
   );
 }
@@ -299,7 +299,7 @@ async function detachExternalIssue(args: z.infer<typeof DetachExternalIssueSchem
   return result.match(
     (_response) => ({ success: true, id, issue_id }),
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'case operation');
     },
   );
 }

--- a/src/operations/custom-fields.ts
+++ b/src/operations/custom-fields.ts
@@ -8,7 +8,7 @@
 import { z } from 'zod';
 import { getApiClient } from '../client/index.js';
 import { toolRegistry } from '../utils/registry.js';
-import { toResultAsync } from '../utils/errors.js';
+import { toResultAsync, createToolError } from '../utils/errors.js';
 import { IdSchema } from '../utils/validation.js';
 
 // ============================================================================
@@ -102,7 +102,7 @@ async function listCustomFields(args: z.infer<typeof ListCustomFieldsSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'custom field operation');
     },
   );
 }
@@ -119,7 +119,7 @@ async function getCustomField(args: z.infer<typeof GetCustomFieldSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'custom field operation');
     },
   );
 }
@@ -135,7 +135,7 @@ async function createCustomField(args: z.infer<typeof CreateCustomFieldSchema>) 
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'custom field operation');
     },
   );
 }
@@ -152,7 +152,7 @@ async function updateCustomField(args: z.infer<typeof UpdateCustomFieldSchema>) 
   return result.match(
     (response: any) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'custom field operation');
     },
   );
 }
@@ -169,7 +169,7 @@ async function deleteCustomField(args: z.infer<typeof DeleteCustomFieldSchema>) 
   return result.match(
     (_response: any) => ({ success: true, id }),
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'custom field operation');
     },
   );
 }

--- a/src/operations/defects.ts
+++ b/src/operations/defects.ts
@@ -8,7 +8,7 @@
 import { z } from 'zod';
 import { getApiClient } from '../client/index.js';
 import { toolRegistry } from '../utils/registry.js';
-import { toResultAsync } from '../utils/errors.js';
+import { toResultAsync, createToolError } from '../utils/errors.js';
 import { ProjectCodeSchema, IdSchema } from '../utils/validation.js';
 
 // ============================================================================
@@ -136,7 +136,7 @@ async function listDefects(args: z.infer<typeof ListDefectsSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'defect operation');
     },
   );
 }
@@ -153,7 +153,7 @@ async function getDefect(args: z.infer<typeof GetDefectSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'defect operation');
     },
   );
 }
@@ -170,7 +170,7 @@ async function createDefect(args: z.infer<typeof CreateDefectSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'defect operation');
     },
   );
 }
@@ -187,7 +187,7 @@ async function updateDefect(args: z.infer<typeof UpdateDefectSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'defect operation');
     },
   );
 }
@@ -204,7 +204,7 @@ async function deleteDefect(args: z.infer<typeof DeleteDefectSchema>) {
   return result.match(
     (_response) => ({ success: true, id }),
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'defect operation');
     },
   );
 }
@@ -221,7 +221,7 @@ async function resolveDefect(args: z.infer<typeof ResolveDefectSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'defect operation');
     },
   );
 }
@@ -238,7 +238,7 @@ async function updateDefectStatus(args: z.infer<typeof UpdateDefectStatusSchema>
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'defect operation');
     },
   );
 }

--- a/src/operations/environments.ts
+++ b/src/operations/environments.ts
@@ -8,7 +8,7 @@
 import { z } from 'zod';
 import { getApiClient } from '../client/index.js';
 import { toolRegistry } from '../utils/registry.js';
-import { toResultAsync } from '../utils/errors.js';
+import { toResultAsync, createToolError } from '../utils/errors.js';
 import { ProjectCodeSchema, IdSchema } from '../utils/validation.js';
 
 // ============================================================================
@@ -81,7 +81,7 @@ async function listEnvironments(args: z.infer<typeof ListEnvironmentsSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'environment operation');
     },
   );
 }
@@ -98,7 +98,7 @@ async function getEnvironment(args: z.infer<typeof GetEnvironmentSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'environment operation');
     },
   );
 }
@@ -117,7 +117,7 @@ async function createEnvironment(args: z.infer<typeof CreateEnvironmentSchema>) 
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'environment operation');
     },
   );
 }
@@ -136,7 +136,7 @@ async function updateEnvironment(args: z.infer<typeof UpdateEnvironmentSchema>) 
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'environment operation');
     },
   );
 }
@@ -153,7 +153,7 @@ async function deleteEnvironment(args: z.infer<typeof DeleteEnvironmentSchema>) 
   return result.match(
     (_response) => ({ success: true, id }),
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'environment operation');
     },
   );
 }

--- a/src/operations/milestones.ts
+++ b/src/operations/milestones.ts
@@ -8,7 +8,7 @@
 import { z } from 'zod';
 import { getApiClient } from '../client/index.js';
 import { toolRegistry } from '../utils/registry.js';
-import { toResultAsync } from '../utils/errors.js';
+import { toResultAsync, createToolError } from '../utils/errors.js';
 import { ProjectCodeSchema, IdSchema } from '../utils/validation.js';
 
 // ============================================================================
@@ -80,7 +80,7 @@ async function listMilestones(args: z.infer<typeof ListMilestonesSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'milestone operation');
     },
   );
 }
@@ -97,7 +97,7 @@ async function getMilestone(args: z.infer<typeof GetMilestoneSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'milestone operation');
     },
   );
 }
@@ -114,7 +114,7 @@ async function createMilestone(args: z.infer<typeof CreateMilestoneSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'milestone operation');
     },
   );
 }
@@ -133,7 +133,7 @@ async function updateMilestone(args: z.infer<typeof UpdateMilestoneSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'milestone operation');
     },
   );
 }
@@ -150,7 +150,7 @@ async function deleteMilestone(args: z.infer<typeof DeleteMilestoneSchema>) {
   return result.match(
     (_response) => ({ success: true, id }),
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'milestone operation');
     },
   );
 }

--- a/src/operations/plans.ts
+++ b/src/operations/plans.ts
@@ -8,7 +8,7 @@
 import { z } from 'zod';
 import { getApiClient } from '../client/index.js';
 import { toolRegistry } from '../utils/registry.js';
-import { toResultAsync } from '../utils/errors.js';
+import { toResultAsync, createToolError } from '../utils/errors.js';
 import { ProjectCodeSchema, IdSchema } from '../utils/validation.js';
 
 // ============================================================================
@@ -83,7 +83,7 @@ async function listPlans(args: z.infer<typeof ListPlansSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'plan operation');
     },
   );
 }
@@ -100,7 +100,7 @@ async function getPlan(args: z.infer<typeof GetPlanSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'plan operation');
     },
   );
 }
@@ -117,7 +117,7 @@ async function createPlan(args: z.infer<typeof CreatePlanSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'plan operation');
     },
   );
 }
@@ -134,7 +134,7 @@ async function updatePlan(args: z.infer<typeof UpdatePlanSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'plan operation');
     },
   );
 }
@@ -151,7 +151,7 @@ async function deletePlan(args: z.infer<typeof DeletePlanSchema>) {
   return result.match(
     (_response) => ({ success: true, id }),
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'plan operation');
     },
   );
 }

--- a/src/operations/projects.ts
+++ b/src/operations/projects.ts
@@ -9,7 +9,7 @@ import { z } from 'zod';
 import { ProjectCreateAccessEnum } from 'qaseio';
 import { getApiClient } from '../client/index.js';
 import { toolRegistry } from '../utils/registry.js';
-import { toResultAsync } from '../utils/errors.js';
+import { toResultAsync, createToolError } from '../utils/errors.js';
 import { PaginationSchema, ProjectCodeSchema } from '../utils/validation.js';
 
 // ============================================================================
@@ -83,7 +83,7 @@ async function listProjects(args: z.infer<typeof ListProjectsSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'listing projects');
     },
   );
 }
@@ -100,7 +100,7 @@ async function getProject(args: z.infer<typeof GetProjectSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'getting project');
     },
   );
 }
@@ -130,7 +130,7 @@ async function createProject(args: z.infer<typeof CreateProjectSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'creating project');
     },
   );
 }
@@ -147,7 +147,7 @@ async function deleteProject(args: z.infer<typeof DeleteProjectSchema>) {
   return result.match(
     (_response) => ({ success: true, code }),
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'deleting project');
     },
   );
 }
@@ -168,7 +168,7 @@ async function grantProjectAccess(args: z.infer<typeof GrantProjectAccessSchema>
   return result.match(
     (_response) => ({ success: true, code, member_id, member_type }),
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'granting project access');
     },
   );
 }
@@ -189,7 +189,7 @@ async function revokeProjectAccess(args: z.infer<typeof RevokeProjectAccessSchem
   return result.match(
     (_response) => ({ success: true, code, member_id, member_type }),
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'revoking project access');
     },
   );
 }

--- a/src/operations/results.ts
+++ b/src/operations/results.ts
@@ -8,7 +8,7 @@
 import { z } from 'zod';
 import { getApiClient } from '../client/index.js';
 import { toolRegistry } from '../utils/registry.js';
-import { toResultAsync } from '../utils/errors.js';
+import { toResultAsync, createToolError } from '../utils/errors.js';
 import { ProjectCodeSchema, IdSchema, HashSchema } from '../utils/validation.js';
 
 // ============================================================================
@@ -136,7 +136,7 @@ async function listResults(args: z.infer<typeof ListResultsSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'result operation');
     },
   );
 }
@@ -153,7 +153,7 @@ async function getResult(args: z.infer<typeof GetResultSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'result operation');
     },
   );
 }
@@ -170,7 +170,7 @@ async function createResult(args: z.infer<typeof CreateResultSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'result operation');
     },
   );
 }
@@ -187,7 +187,7 @@ async function createResultsBulk(args: z.infer<typeof CreateResultsBulkSchema>) 
   return result.match(
     (_response) => ({ success: true, count: results.length }),
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'result operation');
     },
   );
 }
@@ -206,7 +206,7 @@ async function updateResult(args: z.infer<typeof UpdateResultSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'result operation');
     },
   );
 }
@@ -223,7 +223,7 @@ async function deleteResult(args: z.infer<typeof DeleteResultSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'result operation');
     },
   );
 }

--- a/src/operations/runs.ts
+++ b/src/operations/runs.ts
@@ -8,7 +8,7 @@
 import { z } from 'zod';
 import { getApiClient } from '../client/index.js';
 import { toolRegistry } from '../utils/registry.js';
-import { toResultAsync } from '../utils/errors.js';
+import { toResultAsync, createToolError } from '../utils/errors.js';
 import { ProjectCodeSchema, IdSchema } from '../utils/validation.js';
 
 // ============================================================================
@@ -122,7 +122,7 @@ async function listRuns(args: z.infer<typeof ListRunsSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'run operation');
     },
   );
 }
@@ -139,7 +139,7 @@ async function getRun(args: z.infer<typeof GetRunSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'run operation');
     },
   );
 }
@@ -156,7 +156,7 @@ async function createRun(args: z.infer<typeof CreateRunSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'run operation');
     },
   );
 }
@@ -173,7 +173,7 @@ async function deleteRun(args: z.infer<typeof DeleteRunSchema>) {
   return result.match(
     (_response) => ({ success: true, id }),
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'run operation');
     },
   );
 }
@@ -190,7 +190,7 @@ async function completeRun(args: z.infer<typeof CompleteRunSchema>) {
   return result.match(
     (_response) => ({ success: true, id, status: 'complete' }),
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'run operation');
     },
   );
 }
@@ -209,7 +209,7 @@ async function getRunPublicLink(args: z.infer<typeof GetRunPublicLinkSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'run operation');
     },
   );
 }
@@ -228,7 +228,7 @@ async function deleteRunPublicLink(args: z.infer<typeof DeleteRunPublicLinkSchem
   return result.match(
     (_response) => ({ success: true, id, public_link_removed: true }),
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'run operation');
     },
   );
 }

--- a/src/operations/search.ts
+++ b/src/operations/search.ts
@@ -8,7 +8,7 @@
 import { z } from 'zod';
 import { getApiClient } from '../client/index.js';
 import { toolRegistry } from '../utils/registry.js';
-import { toResultAsync } from '../utils/errors.js';
+import { toResultAsync, createToolError } from '../utils/errors.js';
 import { QqlExamples } from '../utils/qql-helpers.js';
 
 // ============================================================================
@@ -83,7 +83,7 @@ async function qqlSearch(args: z.infer<typeof QqlSearchSchema>) {
       entities: response.data.result.entities,
     }),
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'search operation');
     },
   );
 }

--- a/src/operations/shared-steps.ts
+++ b/src/operations/shared-steps.ts
@@ -8,7 +8,7 @@
 import { z } from 'zod';
 import { getApiClient } from '../client/index.js';
 import { toolRegistry } from '../utils/registry.js';
-import { toResultAsync } from '../utils/errors.js';
+import { toResultAsync, createToolError } from '../utils/errors.js';
 import { ProjectCodeSchema, HashSchema } from '../utils/validation.js';
 
 // ============================================================================
@@ -88,7 +88,7 @@ async function listSharedSteps(args: z.infer<typeof ListSharedStepsSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'shared step operation');
     },
   );
 }
@@ -105,7 +105,7 @@ async function getSharedStep(args: z.infer<typeof GetSharedStepSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'shared step operation');
     },
   );
 }
@@ -122,7 +122,7 @@ async function createSharedStep(args: z.infer<typeof CreateSharedStepSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'shared step operation');
     },
   );
 }
@@ -141,7 +141,7 @@ async function updateSharedStep(args: z.infer<typeof UpdateSharedStepSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'shared step operation');
     },
   );
 }
@@ -158,7 +158,7 @@ async function deleteSharedStep(args: z.infer<typeof DeleteSharedStepSchema>) {
   return result.match(
     (_response) => ({ success: true, hash }),
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'shared step operation');
     },
   );
 }

--- a/src/operations/suites.ts
+++ b/src/operations/suites.ts
@@ -8,7 +8,7 @@
 import { z } from 'zod';
 import { getApiClient } from '../client/index.js';
 import { toolRegistry } from '../utils/registry.js';
-import { toResultAsync } from '../utils/errors.js';
+import { toResultAsync, createToolError } from '../utils/errors.js';
 import { ProjectCodeSchema, IdSchema } from '../utils/validation.js';
 
 // ============================================================================
@@ -96,7 +96,7 @@ async function listSuites(args: z.infer<typeof ListSuitesSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'suite operation');
     },
   );
 }
@@ -113,7 +113,7 @@ async function getSuite(args: z.infer<typeof GetSuiteSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'suite operation');
     },
   );
 }
@@ -130,7 +130,7 @@ async function createSuite(args: z.infer<typeof CreateSuiteSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'suite operation');
     },
   );
 }
@@ -147,7 +147,7 @@ async function updateSuite(args: z.infer<typeof UpdateSuiteSchema>) {
   return result.match(
     (response) => response.data.result,
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'suite operation');
     },
   );
 }
@@ -164,7 +164,7 @@ async function deleteSuite(args: z.infer<typeof DeleteSuiteSchema>) {
   return result.match(
     (_response) => ({ success: true, id, delete_cases }),
     (error) => {
-      throw new Error(error);
+      throw createToolError(error, 'suite operation');
     },
   );
 }


### PR DESCRIPTION
## Summary

- Implements proper MCP error handling per the [official specification](https://modelcontextprotocol.io/docs/concepts/tools)
- Protocol errors (unknown tool, invalid schema) throw JSON-RPC errors
- Tool execution errors (API failures, validation) now return `isError: true`

### Changes

- Add `ToolExecutionError` class to distinguish tool errors from protocol errors
- Add `createToolError()` helper that generates context-aware suggestions
- Update all operation handlers to use `createToolError()`
- Update `index.ts` to catch errors and return with `isError: true`
- Add tests for new error handling utilities

### Before vs After

**Before:**
```
MCP error -32603: Tool 'create_project' execution failed: Invalid request: Data is invalid.
```

**After:**
```json
{
  "content": [{
    "type": "text", 
    "text": "Invalid request: Data is invalid\n\nSuggestion: The project code may already exist, or the input data is invalid. Use list_projects or get_project to check existing projects."
  }],
  "isError": true
}
```

## Test plan

- [x] All existing tests pass (85 tests)
- [x] New tests added for `ToolExecutionError` and `createToolError`
- [ ] Manual test: run `npm run inspector`, call `create_project` twice with same code, verify error response includes suggestion