### PR TITLE
chore: Support filtering by external issues in list_cases tool

### DIFF
--- a/src/operations/cases.ts
+++ b/src/operations/cases.ts
@@ -29,6 +29,31 @@ const ListCasesSchema = z.object({
   behavior: z.string().optional().describe('Filter by behavior (e.g., "positive", "negative")'),
   automation: z.string().optional().describe('Filter by automation status'),
   status: z.string().optional().describe('Filter by status (e.g., "actual", "draft")'),
+  external_issues_type: z
+    .enum([
+      'asana',
+      'azure-devops',
+      'clickup-app',
+      'github-app',
+      'gitlab-app',
+      'jira-cloud',
+      'jira-server',
+      'linear',
+      'monday',
+      'redmine-app',
+      'trello-app',
+      'youtrack-app',
+    ])
+    .optional()
+    .describe('Filter by external integration type'),
+  external_issues_ids: z
+    .array(z.string())
+    .optional()
+    .describe('Filter by external issue IDs (e.g., Jira ticket keys)'),
+  include: z
+    .string()
+    .optional()
+    .describe('Comma-separated list of entities to include in response (e.g., "external_issues")'),
   limit: z.number().int().positive().max(100).optional().describe('Maximum number of items'),
   offset: z.number().int().nonnegative().optional().describe('Number of items to skip'),
 });
@@ -159,9 +184,9 @@ async function listCases(args: z.infer<typeof ListCasesSchema>) {
       filters.behavior,
       filters.automation,
       filters.status,
-      undefined, // externalIssuesType
-      undefined, // externalIssuesIds
-      undefined, // include
+      filters.external_issues_type,
+      filters.external_issues_ids,
+      filters.include,
       filters.limit,
       filters.offset,
     ),


### PR DESCRIPTION
Add support for `external_issues_type`, `external_issues_ids`, and `include` filter parameters to the `list_cases` tool. These parameters were already supported by the Qase API (getCases) but were hardcoded as undefined in the handler.

Added three optional fields to ListCasesSchema:
    - `external_issues_type` — enum of supported integrations (jira-cloud, jira-server, github-app, linear, asana, etc.)
    - `external_issues_ids` — array of string IDs to filter by external issue keys
    - `include` — comma-separated string for including related entities (e.g., "external_issues")

Use case:
Allows users to filter test cases by linked external issues (e.g., find all cases linked to a specific Jira ticket)

