### PR TITLE
fix(cases): add required type parameter to external issue attach/deta…

### DIFF
--- a/src/operations/cases.ts
+++ b/src/operations/cases.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from 'zod';
+import { TestCaseexternalIssuesTypeEnum } from 'qaseio';
 import { getApiClient } from '../client/index.js';
 import { toolRegistry } from '../utils/registry.js';
 import { toResultAsync, createToolError } from '../utils/errors.js';
@@ -150,6 +151,9 @@ const AttachExternalIssueSchema = z.object({
   code: ProjectCodeSchema,
   id: IdSchema,
   issue_id: z.string().describe('External issue ID (e.g., Jira issue key)'),
+  type: z
+    .enum(['jira-cloud', 'jira-server'])
+    .describe('Type of external issue integration (Jira Cloud or Jira Server)'),
 });
 
 /**
@@ -159,6 +163,9 @@ const DetachExternalIssueSchema = z.object({
   code: ProjectCodeSchema,
   id: IdSchema,
   issue_id: z.string().describe('External issue ID to detach'),
+  type: z
+    .enum(['jira-cloud', 'jira-server'])
+    .describe('Type of external issue integration (Jira Cloud or Jira Server)'),
 });
 
 // ============================================================================
@@ -290,13 +297,13 @@ async function bulkCreateCases(args: z.infer<typeof BulkCreateCasesSchema>) {
  */
 async function attachExternalIssue(args: z.infer<typeof AttachExternalIssueSchema>) {
   const client = getApiClient();
-  const { code, id, issue_id } = args;
+  const { code, id, issue_id, type } = args;
 
   const result = await toResultAsync(
     client.cases.caseAttachExternalIssue(code, {
-      id,
-      issue_id,
-    } as any),
+      type: type as TestCaseexternalIssuesTypeEnum,
+      links: [{ case_id: id, external_issues: [issue_id] }],
+    }),
   );
 
   return result.match(
@@ -312,13 +319,13 @@ async function attachExternalIssue(args: z.infer<typeof AttachExternalIssueSchem
  */
 async function detachExternalIssue(args: z.infer<typeof DetachExternalIssueSchema>) {
   const client = getApiClient();
-  const { code, id, issue_id } = args;
+  const { code, id, issue_id, type } = args;
 
   const result = await toResultAsync(
     client.cases.caseDetachExternalIssue(code, {
-      id,
-      issue_id,
-    } as any),
+      type: type as TestCaseexternalIssuesTypeEnum,
+      links: [{ case_id: id, external_issues: [issue_id] }],
+    }),
   );
 
   return result.match(


### PR DESCRIPTION
## Purpose

The `attach_external_issue` and `detach_external_issue` MCP tools are broken because they send an incorrect payload to the Qase API. The API requires a `type` field (`"jira-cloud"` or `"jira-server"`) and a `links` array structure, but the tools were sending `{ id, issue_id }` with an `as any` cast hiding the type mismatch.

## Changes Made

- Added required `type` enum field (`'jira-cloud' | 'jira-server'`) to both `AttachExternalIssueSchema` and `DetachExternalIssueSchema`
- Fixed `attachExternalIssue` handler to construct correct API payload: `{ type, links: [{ case_id, external_issues }] }`
- Fixed `detachExternalIssue` handler with the same payload correction
- Removed unsafe `as any` casts from both API calls

## Testing

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (existing tests unaffected)

## Review Checklist

- [x] Code follows project style guidelines
- [x] No other tools or behaviors affected
- [x] `qaseio` dependency untouched
- [x] Only `src/operations/cases.ts` modified

## Breaking Changes

The MCP tools `attach_external_issue` and `detach_external_issue` now require a `type` parameter. This is technically a breaking change to the tool schema, but the tools were non-functional without it, so no working integrations are affected.