### PR TITLE
feat: support nested substeps in test case steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.6]
+
+### Added
+
+- Support for nested substeps in `create_case`, `update_case`, and `bulk_create_cases` tools ([#42](https://github.com/qase-tms/qase-mcp-server/issues/42))
+
 ## [1.1.5]
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qase/mcp-server",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "mcpName": "io.qase/mcp-server",
   "description": "Official MCP server for Qase Test Management Platform",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/qase-tms/qase-mcp-server",
     "source": "github"
   },
-  "version": "1.1.5",
+  "version": "1.1.6",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@qase/mcp-server",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "transport": {
         "type": "stdio"
       },

--- a/src/operations/cases.ts
+++ b/src/operations/cases.ts
@@ -79,7 +79,7 @@ const GetCaseSchema = z.object({
  */
 const CaseEnumValueSchema = z.string();
 
-const TestStepSchema = z.object({
+const stepFields = {
   action: z.string().optional().describe('Step action description (used for classic steps)'),
   expected_result: z.string().optional().describe('Expected result for this step'),
   data: z.string().optional().describe('Test data for this step'),
@@ -90,6 +90,14 @@ const TestStepSchema = z.object({
       'Gherkin scenario text (used when steps_type is "gherkin"). Example: "Given a user exists\\nWhen they log in\\nThen they see the dashboard"',
     ),
   attachments: z.array(z.string()).optional().describe('Array of attachment hashes'),
+};
+
+const TestStepSchema = z.object({
+  ...stepFields,
+  steps: z
+    .array(z.object(stepFields).passthrough())
+    .optional()
+    .describe('Nested substeps. Same structure as parent steps, supports further nesting.'),
 });
 
 /**

--- a/src/smoke.test.ts
+++ b/src/smoke.test.ts
@@ -140,6 +140,24 @@ describe('Schema-API Contract Tests', () => {
     ]);
   });
 
+  describe('cases.ts — nested substeps support (Issue #42)', () => {
+    it.each(['create_case', 'update_case'])(
+      '%s: steps items should have a "steps" property for substeps',
+      (toolName) => {
+        const props = getSchemaProperties(toolName);
+        const stepItems = props.steps?.items;
+        expect(stepItems?.properties?.steps).toBeDefined();
+      },
+    );
+
+    it('bulk_create_cases: steps items should have a "steps" property for substeps', () => {
+      const props = getSchemaProperties('bulk_create_cases');
+      const caseItems = props.cases?.items?.properties ?? {};
+      const stepItems = caseItems.steps?.items;
+      expect(stepItems?.properties?.steps).toBeDefined();
+    });
+  });
+
   describe('cases.ts — is_flaky should be boolean', () => {
     assertFieldTypes([
       ['create_case', 'is_flaky', 'boolean'],


### PR DESCRIPTION
## Summary
- Add `steps` property to `TestStepSchema` enabling nested substeps in `create_case`, `update_case`, and `bulk_create_cases` tools
- Uses shared `stepFields` object with `.passthrough()` to support unlimited nesting depth without triggering zodToJsonSchema recursive reference warnings
- Add smoke tests verifying substeps schema presence across all case tools

Closes #42

## Test plan
- [x] Unit tests pass (252/252)
- [x] Integration test with real API: create case with nested substeps, verify creation, cleanup