### PR TITLE
fix: bump qase-api-client to 1.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qase/mcp-server",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qase/mcp-server",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
@@ -14,7 +14,7 @@
         "express": "^4.18.2",
         "form-data": "^4.0.5",
         "neverthrow": "^8.2.0",
-        "qase-api-client": "1.1.5",
+        "qase-api-client": "^1.1.7",
         "zod": "^3.24.2",
         "zod-to-json-schema": "^3.24.3"
       },
@@ -6416,12 +6416,12 @@
       "license": "MIT"
     },
     "node_modules/qase-api-client": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/qase-api-client/-/qase-api-client-1.1.5.tgz",
-      "integrity": "sha512-Ketwqmx2WURSFtMflIbwHM6naJZjssFPX0uBU6Xbdwi33i8pZLeJZFhL2cWFvELDNJdUSod7G8wMt84e+6cyeg==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/qase-api-client/-/qase-api-client-1.1.7.tgz",
+      "integrity": "sha512-kJ3494C+LDmmt6NYeDKJ5JCWMCal7fgbWFGAOPpirK8RzrDANs2httzqHS+oTyS4zVMx5r+uJ4rGBDB4y/1cyA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "axios": "^1.13.5",
+        "axios": "^1.15.0",
         "axios-retry": "^4.5.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "express": "^4.18.2",
     "form-data": "^4.0.5",
     "neverthrow": "^8.2.0",
-    "qase-api-client": "1.1.5",
+    "qase-api-client": "^1.1.7",
     "zod": "^3.24.2",
     "zod-to-json-schema": "^3.24.3"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qase/mcp-server",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "mcpName": "io.qase/mcp-server",
   "description": "Official MCP server for Qase Test Management Platform",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/qase-tms/qase-mcp-server",
     "source": "github"
   },
-  "version": "1.1.6",
+  "version": "1.1.7",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@qase/mcp-server",
-      "version": "1.1.6",
+      "version": "1.1.7",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
- Bumps `qase-api-client` from 1.1.5 to 1.1.7
- Fixes incorrect serialization of `external_issues_ids` array parameter — the SDK was joining the array as CSV (`external_issues[ids][]=A,B`) instead of producing repeated query keys (`external_issues[ids][]=A&external_issues[ids][]=B`), causing 0 results when filtering by multiple external issue IDs

## Test plan
- [ ] Call `list_cases` with a single `external_issues_ids` value — verify results returned
- [ ] Call `list_cases` with multiple `external_issues_ids` values — verify all matching cases returned (OR logic)
- [ ] Call `list_cases` without `external_issues_ids` — verify existing behavior unchanged