### PR TITLE
fix: normalize automation field and guard undefined MCP responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qase/mcp-server",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qase/mcp-server",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "express": "^4.18.2",
         "form-data": "^4.0.5",
         "neverthrow": "^8.2.0",
-        "qase-api-client": "^1.1.7",
+        "qase-api-client": "^1.1.10",
         "zod": "^3.24.2",
         "zod-to-json-schema": "^3.24.3"
       },
@@ -6416,16 +6416,16 @@
       "license": "MIT"
     },
     "node_modules/qase-api-client": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/qase-api-client/-/qase-api-client-1.1.7.tgz",
-      "integrity": "sha512-kJ3494C+LDmmt6NYeDKJ5JCWMCal7fgbWFGAOPpirK8RzrDANs2httzqHS+oTyS4zVMx5r+uJ4rGBDB4y/1cyA==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/qase-api-client/-/qase-api-client-1.1.10.tgz",
+      "integrity": "sha512-ipOHKfr+22mW9zlXy8Fhmp7tPCMlbHAHAFLq4zClf+ZdKltYyt1XYxhvGRa0lH3VoCNEs9db4NL4ja2P5Vu7VQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "axios": "^1.15.0",
+        "axios": "^1.16.0",
         "axios-retry": "^4.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/qs": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "express": "^4.18.2",
     "form-data": "^4.0.5",
     "neverthrow": "^8.2.0",
-    "qase-api-client": "^1.1.7",
+    "qase-api-client": "^1.1.10",
     "zod": "^3.24.2",
     "zod-to-json-schema": "^3.24.3"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qase/mcp-server",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "mcpName": "io.qase/mcp-server",
   "description": "Official MCP server for Qase Test Management Platform",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/qase-tms/qase-mcp-server",
     "source": "github"
   },
-  "version": "1.1.7",
+  "version": "1.1.8",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@qase/mcp-server",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "transport": {
         "type": "stdio"
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,12 +95,15 @@ function createServer(): Server {
       // Execute the tool handler with provided arguments
       const result = await handler(args || {});
 
+      // JSON.stringify(undefined) returns undefined, which breaks MCP's text schema.
+      const text = result === undefined ? 'null' : JSON.stringify(result, null, 2);
+
       // Return result in MCP format
       return {
         content: [
           {
             type: 'text',
-            text: JSON.stringify(result, null, 2),
+            text,
           },
         ],
       };

--- a/src/operations/cases.ts
+++ b/src/operations/cases.ts
@@ -236,11 +236,10 @@ const DetachExternalIssueSchema = z.object({
 // ============================================================================
 
 /**
- * Qase's `automation` field (0=Manual, 1=To be automated, 2=Automated) is
- * deprecated server-side and silently ignored in create/update payloads. The
- * current API stores the same state via two booleans (`isManual` and
- * `isToBeAutomated`), so after the enum normalizer has resolved automation to
- * a numeric id we translate it into the new field pair the API actually reads.
+ * Map the user-facing `automation` enum (0=Manual, 1=To be automated,
+ * 2=Automated) to the current API contract (`isManual` + `isToBeAutomated`).
+ * The legacy `automation` field is deprecated in qase-api-client and dropped
+ * from the outbound payload.
  */
 function applyAutomationMapping(caseData: Record<string, unknown>): Record<string, unknown> {
   const automationId = caseData.automation;
@@ -249,12 +248,12 @@ function applyAutomationMapping(caseData: Record<string, unknown>): Record<strin
     return caseData;
   }
 
-  const mapped: Record<string, unknown> = { ...caseData };
+  const { automation: _drop, ...rest } = caseData;
+  const mapped: Record<string, unknown> = rest;
 
   switch (automationId) {
     case 2: // Automated
       mapped.isManual = 0;
-      mapped.isToBeAutomated = 0;
       break;
     case 1: // To be automated
       mapped.isManual = 1;

--- a/src/operations/cases.ts
+++ b/src/operations/cases.ts
@@ -232,6 +232,45 @@ const DetachExternalIssueSchema = z.object({
 });
 
 // ============================================================================
+// HELPERS
+// ============================================================================
+
+/**
+ * Qase's `automation` field (0=Manual, 1=To be automated, 2=Automated) is
+ * deprecated server-side and silently ignored in create/update payloads. The
+ * current API stores the same state via two booleans (`isManual` and
+ * `isToBeAutomated`), so after the enum normalizer has resolved automation to
+ * a numeric id we translate it into the new field pair the API actually reads.
+ */
+function applyAutomationMapping(caseData: Record<string, unknown>): Record<string, unknown> {
+  const automationId = caseData.automation;
+
+  if (typeof automationId !== 'number') {
+    return caseData;
+  }
+
+  const mapped: Record<string, unknown> = { ...caseData };
+
+  switch (automationId) {
+    case 2: // Automated
+      mapped.isManual = 0;
+      mapped.isToBeAutomated = 0;
+      break;
+    case 1: // To be automated
+      mapped.isManual = 1;
+      mapped.isToBeAutomated = 1;
+      break;
+    case 0: // Manual
+    default:
+      mapped.isManual = 1;
+      mapped.isToBeAutomated = 0;
+      break;
+  }
+
+  return mapped;
+}
+
+// ============================================================================
 // HANDLERS
 // ============================================================================
 
@@ -294,7 +333,7 @@ async function createCase(args: z.infer<typeof CreateCaseSchema>) {
   const client = getApiClient();
   const { code, ...caseData } = args;
 
-  const normalizedCaseData = await normalizeCaseEnums(caseData);
+  const normalizedCaseData = applyAutomationMapping(await normalizeCaseEnums(caseData));
 
   const result = await toResultAsync(client.cases.createCase(code, normalizedCaseData as any));
 
@@ -313,7 +352,7 @@ async function updateCase(args: z.infer<typeof UpdateCaseSchema>) {
   const client = getApiClient();
   const { code, id, ...updateData } = args;
 
-  const normalizedUpdateData = await normalizeCaseEnums(updateData);
+  const normalizedUpdateData = applyAutomationMapping(await normalizeCaseEnums(updateData));
 
   const result = await toResultAsync(
     client.cases.updateCase(code, id, normalizedUpdateData as any),
@@ -351,7 +390,9 @@ async function bulkCreateCases(args: z.infer<typeof BulkCreateCasesSchema>) {
   const client = getApiClient();
   const { code, cases } = args;
 
-  const normalizedCases = await Promise.all(cases.map((caseData) => normalizeCaseEnums(caseData)));
+  const normalizedCases = await Promise.all(
+    cases.map(async (caseData) => applyAutomationMapping(await normalizeCaseEnums(caseData))),
+  );
 
   const result = await toResultAsync(client.cases.bulk(code, { cases: normalizedCases } as any));
 

--- a/src/operations/cases.ts
+++ b/src/operations/cases.ts
@@ -127,7 +127,9 @@ const CreateCaseSchema = z.object({
   behavior: CaseEnumValueSchema.optional().describe(
     'Test behavior (label or numeric ID from workspace configuration)',
   ),
-  automation: z.string().optional().describe('Automation status'),
+  automation: CaseEnumValueSchema.optional().describe(
+    'Automation status (label, slug, or numeric ID: 0=Manual / is-not-automated, 1=To be automated, 2=Automated)',
+  ),
   status: CaseEnumValueSchema.optional().describe(
     'Test case status (label or numeric ID from workspace configuration)',
   ),
@@ -171,7 +173,9 @@ const UpdateCaseSchema = z.object({
   behavior: CaseEnumValueSchema.optional().describe(
     'Test behavior (label or numeric ID from workspace configuration)',
   ),
-  automation: z.string().optional().describe('Automation status'),
+  automation: CaseEnumValueSchema.optional().describe(
+    'Automation status (label, slug, or numeric ID: 0=Manual / is-not-automated, 1=To be automated, 2=Automated)',
+  ),
   status: CaseEnumValueSchema.optional().describe(
     'Test case status (label or numeric ID from workspace configuration)',
   ),

--- a/src/utils/case-enums.test.ts
+++ b/src/utils/case-enums.test.ts
@@ -15,6 +15,16 @@ const defaultFieldSnapshot = {
     ['positive', 2],
     ['negative', 3],
   ]),
+  automation: new Map([
+    ['is-not-automated', 0],
+    ['manual', 0],
+    ['0', 0],
+    ['to-be-automated', 1],
+    ['to be automated', 1],
+    ['1', 1],
+    ['automated', 2],
+    ['2', 2],
+  ]),
 };
 
 describe('normalizeCaseEnums', () => {
@@ -66,6 +76,15 @@ describe('normalizeCaseEnums', () => {
     const normalized = await normalizeCaseEnums(payload);
 
     expect(normalized).toEqual(payload);
+  });
+
+  it('maps automation slug, title, and numeric values to numeric IDs', async () => {
+    expect(await normalizeCaseEnums({ automation: 'Automated' })).toEqual({ automation: 2 });
+    expect(await normalizeCaseEnums({ automation: 'automated' })).toEqual({ automation: 2 });
+    expect(await normalizeCaseEnums({ automation: 'Manual' })).toEqual({ automation: 0 });
+    expect(await normalizeCaseEnums({ automation: 'is-not-automated' })).toEqual({ automation: 0 });
+    expect(await normalizeCaseEnums({ automation: '2' })).toEqual({ automation: 2 });
+    expect(await normalizeCaseEnums({ automation: 1 })).toEqual({ automation: 1 });
   });
 
   it('clears cache on fetch error and retries on next call', async () => {

--- a/src/utils/case-enums.ts
+++ b/src/utils/case-enums.ts
@@ -1,6 +1,13 @@
 import { getApiClient } from '../client/index.js';
 
-type CaseEnumField = 'priority' | 'type' | 'behavior' | 'severity' | 'status' | 'layer';
+type CaseEnumField =
+  | 'priority'
+  | 'type'
+  | 'behavior'
+  | 'severity'
+  | 'status'
+  | 'layer'
+  | 'automation';
 
 const caseEnumFields: CaseEnumField[] = [
   'priority',
@@ -9,6 +16,7 @@ const caseEnumFields: CaseEnumField[] = [
   'severity',
   'status',
   'layer',
+  'automation',
 ];
 
 interface SystemFieldOption {


### PR DESCRIPTION
## Summary

Fixes broken automation status handling when creating and updating test cases via the MCP server. The deprecated `automation` enum (0=Manual, 1=To be automated, 2=Automated) is now resolved from labels/slugs/ids and mapped to the current API contract (`isManual` + `isToBeAutomated`), with the legacy field dropped from the outbound payload.

## Changes

- Add `automation` to the enum normalizer so labels (`Automated`), slugs (`to-be-automated`) and numeric ids all resolve correctly.
- Add `applyAutomationMapping` to translate the resolved enum into `isManual`/`isToBeAutomated` and strip the deprecated `automation` key — applied in `create_case`, `update_case` and `bulk_create_cases`.
- Guard `undefined` MCP responses so `JSON.stringify(undefined)` no longer breaks the text schema.
- Bump `qase-api-client` to 1.1.10 and package version to 1.1.8.

## Testing

Verified end-to-end against the real Qase API (project DEVX) by running the build of this branch over stdio:

| Operation | Input forms | Result |
|---|---|---|
| `create_case` | numeric `0/1/2`, label, slug | correct `isManual`/`isToBeAutomated` in all forms |
| `bulk_create_cases` | mixed automation + case without the field | each case mapped correctly (the original mass-create bug) |
| `update_case` | switching automation on existing cases | statuses toggle correctly |

Mapping confirmed: `2`→`isManual=false,isToBeAutomated=false`; `1`→`true,true`; `0`→`true,false`; no field → default Manual. All test cases were deleted after verification.