### PR TITLE
feat: external issue linking, bulk case creation, and discovery activation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.1]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`qase_external_issue_link`** — Link or unlink test cases and test runs to issues in an external tracker (Jira Cloud / Jira Server), wrapping `POST /v1/case/{code}/external-issue/attach`, `.../detach`, and `POST /v1/run/{code}/external-issue`. A case can hold several links; a run holds one, and detaching clears it. ([#64](https://github.com/qase-tms/qase-mcp-server/issues/64))
 - **`qase_get`** now requests external issue links for cases and runs by default (`include=external_issues` / `include=external_issue`), so a link created via `qase_external_issue_link` can be verified without leaving the MCP client. The new `include` parameter overrides the default; if a deployment rejects the value, the request is retried without it. ([#65](https://github.com/qase-tms/qase-mcp-server/issues/65))
 
+- **`qase_case_bulk_create`** — Create up to 100 test cases in a single request, restoring the bulk creation that v1 offered as `bulk_create_cases`. Unlike the v1 tool it normalises enum labels per case, so `priority: "high"` works the same as in `qase_case_upsert`.
+
 ### Fixed
 
 - `qase_discover_tools` no longer skips activation when the `activate` argument is omitted. Tool handlers receive raw MCP arguments, so the schema default never applied and matched tools stayed hidden from the client's tool list.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`qase_external_issue_link`** — Link or unlink test cases and test runs to issues in an external tracker (Jira Cloud / Jira Server), wrapping `POST /v1/case/{code}/external-issue/attach`, `.../detach`, and `POST /v1/run/{code}/external-issue`. A case can hold several links; a run holds one, and detaching clears it. ([#64](https://github.com/qase-tms/qase-mcp-server/issues/64))
+- **`qase_get`** now requests external issue links for cases and runs by default (`include=external_issues` / `include=external_issue`), so a link created via `qase_external_issue_link` can be verified without leaving the MCP client. The new `include` parameter overrides the default; if a deployment rejects the value, the request is retried without it. ([#65](https://github.com/qase-tms/qase-mcp-server/issues/65))
+
 ## [2.0.0]
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`qase_external_issue_link`** — Link or unlink test cases and test runs to issues in an external tracker (Jira Cloud / Jira Server), wrapping `POST /v1/case/{code}/external-issue/attach`, `.../detach`, and `POST /v1/run/{code}/external-issue`. A case can hold several links; a run holds one, and detaching clears it. ([#64](https://github.com/qase-tms/qase-mcp-server/issues/64))
 - **`qase_get`** now requests external issue links for cases and runs by default (`include=external_issues` / `include=external_issue`), so a link created via `qase_external_issue_link` can be verified without leaving the MCP client. The new `include` parameter overrides the default; if a deployment rejects the value, the request is retried without it. ([#65](https://github.com/qase-tms/qase-mcp-server/issues/65))
 
+### Fixed
+
+- `qase_discover_tools` no longer skips activation when the `activate` argument is omitted. Tool handlers receive raw MCP arguments, so the schema default never applied and matched tools stayed hidden from the client's tool list.
+
 ## [2.0.0]
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The Qase MCP Server lets AI assistants (Claude, Cursor, Codex, and any other MCP
 
 **Features:**
 
-- **30 task-oriented tools** (31 total, including `qase_discover_tools`) — consolidated from 83 v1 tools for lower token usage and better LLM accuracy
+- **31 task-oriented tools** (32 total, including `qase_discover_tools`) — consolidated from 83 v1 tools for lower token usage and better LLM accuracy
 - **Composite tools** — multi-step workflows in a single call: CI reporting, defect triage, regression run setup
 - **QQL support** — Qase Query Language for advanced searches across cases, runs, results, defects, and plans
 - **Project context bootstrap** — one call returns full project structure (suites, milestones, environments, users, custom fields)
@@ -80,13 +80,13 @@ v2 consolidates 83 v1 tools into **29 task-oriented tools** (30 total, including
 
 ## Tools
 
-31 tools across 6 groups (30 task-oriented tools plus `qase_discover_tools` for on-demand activation of secondary tools):
+32 tools across 6 groups (31 task-oriented tools plus `qase_discover_tools` for on-demand activation of secondary tools):
 
 | Group | Count | Description |
 | --- | --- | --- |
 | Read | 2 | Fetch any entity by type/ID, or bootstrap full project context in one call |
 | QQL | 2 | Search across cases, runs, results, defects, and plans with Qase Query Language |
-| Write | 22 | Create, update, and delete cases, runs, results, defects, suites, milestones, plans, shared steps, environments, and attachments; link cases and runs to Jira issues |
+| Write | 23 | Create, update, and delete cases (single or up to 100 at once), runs, results, defects, suites, milestones, plans, shared steps, environments, and attachments; link cases and runs to Jira issues |
 | Composite | 3 | Multi-step workflows in one call: CI reporting, defect triage, regression run setup |
 | Escape hatch | 1 | Direct REST API access for any endpoint not covered by the tools above |
 | Meta | 1 | `qase_discover_tools` — find and activate secondary tools on demand |

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The Qase MCP Server lets AI assistants (Claude, Cursor, Codex, and any other MCP
 
 **Features:**
 
-- **29 task-oriented tools** (30 total, including `qase_discover_tools`) — consolidated from 83 v1 tools for lower token usage and better LLM accuracy
+- **30 task-oriented tools** (31 total, including `qase_discover_tools`) — consolidated from 83 v1 tools for lower token usage and better LLM accuracy
 - **Composite tools** — multi-step workflows in a single call: CI reporting, defect triage, regression run setup
 - **QQL support** — Qase Query Language for advanced searches across cases, runs, results, defects, and plans
 - **Project context bootstrap** — one call returns full project structure (suites, milestones, environments, users, custom fields)
@@ -80,13 +80,13 @@ v2 consolidates 83 v1 tools into **29 task-oriented tools** (30 total, including
 
 ## Tools
 
-30 tools across 6 groups (29 task-oriented tools plus `qase_discover_tools` for on-demand activation of secondary tools):
+31 tools across 6 groups (30 task-oriented tools plus `qase_discover_tools` for on-demand activation of secondary tools):
 
 | Group | Count | Description |
 | --- | --- | --- |
 | Read | 2 | Fetch any entity by type/ID, or bootstrap full project context in one call |
 | QQL | 2 | Search across cases, runs, results, defects, and plans with Qase Query Language |
-| Write | 21 | Create, update, and delete cases, runs, results, defects, suites, milestones, plans, shared steps, environments, and attachments |
+| Write | 22 | Create, update, and delete cases, runs, results, defects, suites, milestones, plans, shared steps, environments, and attachments; link cases and runs to Jira issues |
 | Composite | 3 | Multi-step workflows in one call: CI reporting, defect triage, regression run setup |
 | Escape hatch | 1 | Direct REST API access for any endpoint not covered by the tools above |
 | Meta | 1 | `qase_discover_tools` — find and activate secondary tools on demand |

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -41,7 +41,7 @@ All 83 v1 tools mapped to their v2 equivalents.
 | `create_case` | `qase_case_upsert` (omit `id`) | Pass all case fields; no `id` = create |
 | `update_case` | `qase_case_upsert` (include `id`) | Include `id` to update existing case |
 | `delete_case` | `qase_case_delete` | — |
-| `bulk_create_cases` | `qase_case_upsert` (call per case) | Call once per case without `id` |
+| `bulk_create_cases` | `qase_case_bulk_create` | Same shape: `cases` array, up to 100 per call |
 | `attach_external_issue` | `qase_api` | Use escape hatch: `POST /case/{code}/{id}/external-issues` |
 | `detach_external_issue` | `qase_api` | Use escape hatch: `DELETE /case/{code}/{id}/external-issues` |
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,13 +1,13 @@
 # Tool Reference
 
-The Qase MCP Server exposes **30 tools** across 6 groups: Read, QQL, Write, Composite, Escape hatch, and Meta.
+The Qase MCP Server exposes **31 tools** across 6 groups: Read, QQL, Write, Composite, Escape hatch, and Meta.
 
 ## Discovery model
 
 To keep context-token usage low, tools are split into two visibility tiers:
 
 - **`core`** — always listed to the MCP client, no activation needed (13 tools).
-- **`discoverable`** — hidden by default; the LLM finds and activates them on demand via `qase_discover_tools`, which searches tool names/descriptions and activates matches for the rest of the session (17 tools, mostly deletes and secondary write operations).
+- **`discoverable`** — hidden by default; the LLM finds and activates them on demand via `qase_discover_tools`, which searches tool names/descriptions and activates matches for the rest of the session (18 tools, mostly deletes and secondary write operations).
 
 If a tool you need isn't showing up in your client's tool list, call `qase_discover_tools` with a query (e.g. `"delete"`, `"milestone"`, `"attachment"`) to activate it first.
 
@@ -17,7 +17,7 @@ Every tool's schema uses "label or numeric ID" strings for Qase's configurable e
 
 | Tool | Description | Key params | Visibility |
 | --- | --- | --- | --- |
-| `qase_get` | Get any Qase entity by type and ID. Supports field projection via `fields`. `code` is required for project-scoped entities (case, suite, run, result, plan, defect, milestone, environment, shared_step, shared_parameter, configuration); optional for global entities (user, author, attachment, custom_field). | `entity` (enum: case, suite, run, result, plan, defect, milestone, environment, shared_step, shared_parameter, configuration, attachment, author, user, custom_field), `code` (optional), `id` (number or hash string), `fields` (optional string array — pass `["*"]` for all) | core |
+| `qase_get` | Get any Qase entity by type and ID. Supports field projection via `fields`. `code` is required for project-scoped entities (case, suite, run, result, plan, defect, milestone, environment, shared_step, shared_parameter, configuration); optional for global entities (user, author, attachment, custom_field). Cases and runs automatically request their external issue links (`external_issues` / `external_issue`); override with `include`. | `entity` (enum: case, suite, run, result, plan, defect, milestone, environment, shared_step, shared_parameter, configuration, attachment, author, user, custom_field), `code` (optional), `id` (number or hash string), `fields` (optional string array — pass `["*"]` for all), `include` (optional string) | core |
 | `qase_project_context` | Get full project context in one call: project details, suites tree, milestones, environments, custom fields, and users. Cached for 5 minutes. Recommended as the first call when starting work with a project. | `code` | core |
 
 ## QQL tools
@@ -30,7 +30,7 @@ Every tool's schema uses "label or numeric ID" strings for Qase's configurable e
 ## Write tools
 
 <details>
-<summary>Write tools (21)</summary>
+<summary>Write tools (22)</summary>
 
 | Tool | Description | Key params | Visibility |
 | --- | --- | --- | --- |
@@ -55,6 +55,7 @@ Every tool's schema uses "label or numeric ID" strings for Qase's configurable e
 | `qase_environment_delete` | Delete a test environment by project code and environment ID. | `code`, `id` | discoverable |
 | `qase_attachment_upload` | Upload a file attachment. Accepts the file as a base64 encoded string or an absolute path. Returns the attachment hash that can be referenced in test cases and results. | `code`, `file` (base64 string or absolute path), `filename` | discoverable |
 | `qase_attachment_delete` | Delete an attachment by its hash. | `hash` | discoverable |
+| `qase_external_issue_link` | Link or unlink test cases and test runs to issues in an external tracker (Jira Cloud or Jira Server). A case can be linked to several issues; a run can have only one link, and attaching a new issue replaces the previous one. Detaching a run clears its link. Read linked issues back with `qase_get`. | `code`, `entity` (enum: case, run), `action` (enum: attach, detach), `type` (enum: jira-cloud, jira-server), `links` (array: `id`, `issues` — issue keys such as `PROJ-1234`) | discoverable |
 
 </details>
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,13 +1,13 @@
 # Tool Reference
 
-The Qase MCP Server exposes **31 tools** across 6 groups: Read, QQL, Write, Composite, Escape hatch, and Meta.
+The Qase MCP Server exposes **32 tools** across 6 groups: Read, QQL, Write, Composite, Escape hatch, and Meta.
 
 ## Discovery model
 
 To keep context-token usage low, tools are split into two visibility tiers:
 
 - **`core`** — always listed to the MCP client, no activation needed (13 tools).
-- **`discoverable`** — hidden by default; the LLM finds and activates them on demand via `qase_discover_tools`, which searches tool names/descriptions and activates matches for the rest of the session (18 tools, mostly deletes and secondary write operations).
+- **`discoverable`** — hidden by default; the LLM finds and activates them on demand via `qase_discover_tools`, which searches tool names/descriptions and activates matches for the rest of the session (19 tools, mostly deletes and secondary write operations).
 
 If a tool you need isn't showing up in your client's tool list, call `qase_discover_tools` with a query (e.g. `"delete"`, `"milestone"`, `"attachment"`) to activate it first.
 
@@ -30,11 +30,12 @@ Every tool's schema uses "label or numeric ID" strings for Qase's configurable e
 ## Write tools
 
 <details>
-<summary>Write tools (22)</summary>
+<summary>Write tools (23)</summary>
 
 | Tool | Description | Key params | Visibility |
 | --- | --- | --- | --- |
 | `qase_case_upsert` | Create or update a test case. If `id` is provided, updates the existing case; if omitted, creates a new one. Enum fields (priority, severity, type, etc.) accept both labels ("high", "blocker") and numeric IDs — the server normalizes automatically. | `code`, `id` (optional), `title` (1-255 chars), `description`, `preconditions`, `postconditions`, `severity`, `priority`, `type`, `layer`, `behavior`, `automation`, `status` (all label-or-ID strings), `is_flaky`, `suite_id`, `milestone_id`, `steps` (array, supports nesting), `steps_type` (enum: classic, gherkin), `tags`, `attachments`, `custom_field` | core |
+| `qase_case_bulk_create` | Create up to 100 test cases in a single request. Use instead of calling `qase_case_upsert` repeatedly when importing or generating several cases at once. Enum fields accept labels or numeric IDs. Creates only — use `qase_case_upsert` with an `id` to update. Returns the IDs of the created cases in submission order. | `code`, `cases` (array, 1-100 — same fields as `qase_case_upsert` without `id`) | discoverable |
 | `qase_case_delete` | Delete a test case by project code and case ID. | `code`, `id` | discoverable |
 | `qase_defect_upsert` | Create or update a defect. If `id` is provided, updates (including status changes and resolve). If omitted, creates a new defect. Set `status: "resolved"` to resolve an existing defect. | `code`, `id` (optional), `title` (1-255 chars), `actual_result`, `severity` (enum, see [below](#case-enum-values)), `status` (enum: open, in_progress, resolved, invalid), `tags`, `attachments`, `custom_field` | core |
 | `qase_defect_delete` | Delete a defect by project code and defect ID. | `code`, `id` | discoverable |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qase/mcp-server",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qase/mcp-server",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qase/mcp-server",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "mcpName": "io.qase/mcp-server",
   "description": "Official MCP server for Qase Test Management Platform",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/qase-tms/qase-mcp-server",
     "source": "github"
   },
-  "version": "2.0.0",
+  "version": "2.0.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@qase/mcp-server",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/operations-v2/index.ts
+++ b/src/operations-v2/index.ts
@@ -16,6 +16,7 @@ import './write/plans.js';
 import './write/shared-steps.js';
 import './write/environments.js';
 import './write/attachments.js';
+import './write/external-issues.js';
 
 // Composites
 import './composites/ci-report.js';

--- a/src/operations-v2/index.ts
+++ b/src/operations-v2/index.ts
@@ -7,6 +7,7 @@ import './qql/index.js';
 
 // Write tools
 import './write/cases.js';
+import './write/cases-bulk.js';
 import './write/runs.js';
 import './write/results.js';
 import './write/defects.js';

--- a/src/operations-v2/meta/discover.test.ts
+++ b/src/operations-v2/meta/discover.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Tests for qase_discover_tools.
+ *
+ * Tool handlers receive raw MCP arguments — the server does not run them
+ * through the Zod schema — so schema defaults never materialise. The handler
+ * has to apply them itself.
+ */
+
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { z } from 'zod';
+import { toolRegistry } from '../../utils/registry.js';
+
+import './discover.js';
+
+function invoke(args: Record<string, unknown>) {
+  const handler = toolRegistry.getHandler('qase_discover_tools')!;
+  return handler(args) as Promise<{ found: number; activated: number; tools: { name: string }[] }>;
+}
+
+beforeEach(() => {
+  toolRegistry.unregister('probe_secondary_tool');
+  toolRegistry.register({
+    name: 'probe_secondary_tool',
+    description: 'A probe tool used to verify discovery activation.',
+    schema: z.object({}),
+    handler: async () => ({}),
+    visibility: 'discoverable',
+  });
+});
+
+describe('qase_discover_tools — activation', () => {
+  it('activates matched tools when `activate` is omitted', async () => {
+    expect(toolRegistry.getTools().map((t) => t.name)).not.toContain('probe_secondary_tool');
+
+    const result = await invoke({ query: 'probe tool used to verify' });
+
+    expect(result.tools.map((t) => t.name)).toContain('probe_secondary_tool');
+    expect(result.activated).toBe(1);
+    expect(toolRegistry.getTools().map((t) => t.name)).toContain('probe_secondary_tool');
+  });
+
+  it('does not activate anything when `activate` is false', async () => {
+    const result = await invoke({ query: 'probe tool used to verify', activate: false });
+
+    expect(result.found).toBe(1);
+    expect(result.activated).toBe(0);
+    expect(toolRegistry.getTools().map((t) => t.name)).not.toContain('probe_secondary_tool');
+  });
+});

--- a/src/operations-v2/meta/discover.ts
+++ b/src/operations-v2/meta/discover.ts
@@ -30,7 +30,10 @@ const Schema = z.object({
 });
 
 async function handler(args: z.infer<typeof Schema>) {
-  const { query, category, activate } = args;
+  const { query, category } = args;
+  // Handlers receive raw MCP arguments, so the schema default never runs —
+  // apply it here or discovery silently stops activating anything.
+  const activate = args.activate ?? true;
 
   let matches = query ? toolRegistry.searchTools(query) : toolRegistry.getAllTools();
 

--- a/src/operations-v2/read/get.test.ts
+++ b/src/operations-v2/read/get.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for qase_get — entity fetching with `include` support.
+ *
+ * Linked external issues are only returned by the Qase API when the request
+ * asks for them via `include`, so qase_get requests them by default for cases
+ * and runs.
+ */
+
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { setTestEnv } from '../../utils/test-helpers.js';
+
+setTestEnv();
+
+const mockGetCase = jest.fn();
+const mockGetRun = jest.fn();
+const mockGetSuite = jest.fn();
+
+jest.mock('../../client/index.js', () => ({
+  getApiClient: () => ({
+    cases: { getCase: mockGetCase },
+    runs: { getRun: mockGetRun },
+    suites: { getSuite: mockGetSuite },
+  }),
+}));
+
+import './get.js';
+import { toolRegistry } from '../../utils/registry.js';
+
+const ok = (result: unknown) => () => Promise.resolve({ data: { status: true, result } });
+
+function invoke(args: Record<string, unknown>) {
+  const handler = toolRegistry.getHandler('qase_get')!;
+  return handler(args);
+}
+
+beforeEach(() => {
+  mockGetCase.mockReset().mockImplementation(ok({ id: 1, external_issues: [] }));
+  mockGetRun.mockReset().mockImplementation(ok({ id: 400, external_issue: null }));
+  mockGetSuite.mockReset().mockImplementation(ok({ id: 5 }));
+});
+
+describe('qase_get — include parameter', () => {
+  it('exposes an `include` field in its schema', () => {
+    const tool = toolRegistry.getAllTools().find((t) => t.name === 'qase_get');
+    const props = (tool?.inputSchema as any)?.properties ?? {};
+    expect(props.include).toBeDefined();
+  });
+
+  it('requests external_issues for a case by default', async () => {
+    await invoke({ entity: 'case', code: 'DEMO', id: 1 });
+    expect(mockGetCase).toHaveBeenCalledWith('DEMO', 1, 'external_issues');
+  });
+
+  it('requests external_issue for a run by default', async () => {
+    await invoke({ entity: 'run', code: 'DEMO', id: 400 });
+    expect(mockGetRun).toHaveBeenCalledWith('DEMO', 400, 'external_issue');
+  });
+
+  it('returns the external issues in the result', async () => {
+    mockGetCase.mockImplementation(ok({ id: 1, external_issues: [{ type: 'jira-cloud' }] }));
+    const result = (await invoke({ entity: 'case', code: 'DEMO', id: 1 })) as any;
+    expect(result.external_issues).toEqual([{ type: 'jira-cloud' }]);
+  });
+
+  it('uses an explicit include over the default', async () => {
+    await invoke({ entity: 'case', code: 'DEMO', id: 1, include: 'external_issues,something' });
+    expect(mockGetCase).toHaveBeenCalledWith('DEMO', 1, 'external_issues,something');
+  });
+
+  it('does not send include for entities that do not support it', async () => {
+    await invoke({ entity: 'suite', code: 'DEMO', id: 5 });
+    expect(mockGetSuite).toHaveBeenCalledWith('DEMO', 5);
+  });
+});
+
+describe('qase_get — include fallback', () => {
+  it('retries without include when the default include is rejected', async () => {
+    mockGetCase.mockImplementation((_code: string, _id: number, include?: string) => {
+      if (include) {
+        const error: any = new Error('Invalid include value');
+        error.isAxiosError = true;
+        error.response = { status: 400, data: { errorMessage: 'Invalid include value' } };
+        return Promise.reject(error);
+      }
+      return Promise.resolve({ data: { status: true, result: { id: 1 } } });
+    });
+
+    const result = (await invoke({ entity: 'case', code: 'DEMO', id: 1 })) as any;
+
+    expect(result).toEqual({ id: 1 });
+    expect(mockGetCase).toHaveBeenNthCalledWith(1, 'DEMO', 1, 'external_issues');
+    expect(mockGetCase).toHaveBeenNthCalledWith(2, 'DEMO', 1, undefined);
+  });
+
+  it('does not retry when the caller asked for include explicitly', async () => {
+    mockGetCase.mockImplementation(() => {
+      const error: any = new Error('Invalid include value');
+      error.isAxiosError = true;
+      error.response = { status: 400, data: { errorMessage: 'Invalid include value' } };
+      return Promise.reject(error);
+    });
+
+    await expect(
+      invoke({ entity: 'case', code: 'DEMO', id: 1, include: 'external_issues' }),
+    ).rejects.toThrow(/Invalid include value/);
+
+    expect(mockGetCase).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the original error when the case does not exist', async () => {
+    mockGetCase.mockImplementation(() => {
+      const error: any = new Error('Case not found');
+      error.isAxiosError = true;
+      error.response = { status: 404, data: { errorMessage: 'Case not found' } };
+      return Promise.reject(error);
+    });
+
+    await expect(invoke({ entity: 'case', code: 'DEMO', id: 999 })).rejects.toThrow(
+      /Case not found/,
+    );
+  });
+});

--- a/src/operations-v2/read/get.ts
+++ b/src/operations-v2/read/get.ts
@@ -47,12 +47,33 @@ const Schema = z.object({
     .describe(
       'Optional field projection — only return these top-level fields. Pass ["*"] for all fields.',
     ),
+  include: z
+    .string()
+    .optional()
+    .describe(
+      'Comma-separated list of related entities to include in the response. ' +
+        'Cases and runs already request their external issue links by default ' +
+        '("external_issues" / "external_issue"); pass this only to override that.',
+    ),
 });
 
-const FETCHERS: Record<string, (client: any, code: string, id: any) => Promise<any>> = {
-  case: (c, code, id) => c.cases.getCase(code, id),
+/**
+ * Related entities requested automatically so linked issues are visible without
+ * the caller knowing about the `include` query parameter. The Qase API omits
+ * these fields entirely unless they are asked for.
+ */
+const DEFAULT_INCLUDE: Record<string, string> = {
+  case: 'external_issues',
+  run: 'external_issue',
+};
+
+const FETCHERS: Record<
+  string,
+  (client: any, code: string, id: any, include?: string) => Promise<any>
+> = {
+  case: (c, code, id, include) => c.cases.getCase(code, id, include),
   suite: (c, code, id) => c.suites.getSuite(code, id),
-  run: (c, code, id) => c.runs.getRun(code, id),
+  run: (c, code, id, include) => c.runs.getRun(code, id, include),
   result: (c, code, id) => c.results.getResult(code, id),
   plan: (c, code, id) => c.plans.getPlan(code, id),
   defect: (c, code, id) => c.defects.getDefect(code, id),
@@ -68,7 +89,7 @@ const FETCHERS: Record<string, (client: any, code: string, id: any) => Promise<a
 };
 
 async function handler(args: z.infer<typeof Schema>) {
-  const { entity, code, id, fields: fieldList } = args;
+  const { entity, code, id, fields: fieldList, include } = args;
 
   if (ENTITIES_REQUIRING_CODE.has(entity) && !code) {
     throw createToolError(`Project code is required for entity type "${entity}"`, 'get operation');
@@ -78,7 +99,18 @@ async function handler(args: z.infer<typeof Schema>) {
   const fetcher = FETCHERS[entity];
   if (!fetcher) throw createToolError(`Unknown entity type: ${entity}`, 'get operation');
 
-  const result = await toResultAsync(fetcher(client, code || '', id));
+  const effectiveInclude = include ?? DEFAULT_INCLUDE[entity];
+  const isDefaultInclude = !include && effectiveInclude !== undefined;
+
+  let result = await toResultAsync(fetcher(client, code || '', id, effectiveInclude));
+
+  // Deployments that don't know the `include` value (older self-hosted
+  // instances) reject the request outright — retry without it rather than
+  // failing a plain get. An explicit `include` from the caller is never
+  // silently dropped.
+  if (result.isErr() && isDefaultInclude) {
+    result = await toResultAsync(fetcher(client, code || '', id, undefined));
+  }
 
   return result.match(
     (response) => {

--- a/src/operations-v2/write/case-fields.ts
+++ b/src/operations-v2/write/case-fields.ts
@@ -1,0 +1,89 @@
+/**
+ * Shared test case field definitions.
+ *
+ * `qase_case_upsert` and `qase_case_bulk_create` accept the same case body, so
+ * the schema and the automation mapping live here instead of being duplicated
+ * — a new case field only has to be added once.
+ */
+
+import { z } from 'zod';
+
+const stepFields = {
+  action: z.string().optional().describe('Step action (classic steps)'),
+  expected_result: z.string().optional().describe('Expected result'),
+  data: z.string().optional().describe('Test data'),
+  value: z.string().optional().describe('Gherkin scenario text (when steps_type is "gherkin")'),
+  attachments: z.array(z.string()).optional().describe('Attachment hashes'),
+};
+
+export const TestStepSchema = z.object({
+  ...stepFields,
+  steps: z
+    .array(z.object(stepFields).passthrough())
+    .optional()
+    .describe('Nested substeps. Same structure as parent steps, supports further nesting.'),
+});
+
+export const CaseFieldsSchema = z.object({
+  title: z.string().min(1).max(255).describe('Test case title'),
+  description: z.string().optional(),
+  preconditions: z.string().optional(),
+  postconditions: z.string().optional(),
+  severity: z.string().optional().describe('Severity label or numeric ID'),
+  priority: z
+    .string()
+    .optional()
+    .describe('Priority label or numeric ID (0=not set, 1=high, 2=medium, 3=low)'),
+  type: z.string().optional().describe('Type label or numeric ID'),
+  layer: z.string().optional().describe('Layer label or numeric ID'),
+  behavior: z.string().optional().describe('Behavior label or numeric ID'),
+  automation: z
+    .string()
+    .optional()
+    .describe(
+      'Automation status (label, slug, or numeric ID: 0=Manual / is-not-automated, 1=To be automated, 2=Automated)',
+    ),
+  status: z.string().optional().describe('Status label or numeric ID'),
+  is_flaky: z.boolean().optional(),
+  suite_id: z.number().int().positive().optional(),
+  milestone_id: z.number().int().positive().optional(),
+  steps: z.array(TestStepSchema).optional(),
+  steps_type: z.enum(['classic', 'gherkin']).optional(),
+  tags: z.array(z.string()).optional(),
+  attachments: z.array(z.string()).optional(),
+  custom_field: z.record(z.any()).optional(),
+});
+
+/**
+ * Map the user-facing `automation` enum (0=Manual, 1=To be automated,
+ * 2=Automated) to the current API contract (`isManual` + `isToBeAutomated`).
+ * The legacy `automation` field is deprecated in qase-api-client and dropped
+ * from the outbound payload.
+ */
+export function applyAutomationMapping(caseData: Record<string, unknown>): Record<string, unknown> {
+  const automationId = caseData.automation;
+
+  if (typeof automationId !== 'number') {
+    return caseData;
+  }
+
+  const { automation: _drop, ...rest } = caseData;
+  const mapped: Record<string, unknown> = rest;
+
+  switch (automationId) {
+    case 2: // Automated
+      mapped.isManual = 0;
+      break;
+    case 1: // To be automated
+      mapped.isManual = 1;
+      mapped.isToBeAutomated = 1;
+      break;
+    case 0: // Manual
+    default:
+      mapped.isManual = 1;
+      mapped.isToBeAutomated = 0;
+      break;
+  }
+
+  return mapped;
+}

--- a/src/operations-v2/write/cases-bulk.test.ts
+++ b/src/operations-v2/write/cases-bulk.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for qase_case_bulk_create — creating many test cases in one request.
+ */
+
+import { describe, it, expect, beforeEach, beforeAll } from '@jest/globals';
+import { setTestEnv } from '../../utils/test-helpers.js';
+
+setTestEnv();
+
+const mockBulk = jest.fn();
+const mockCreateCase = jest.fn();
+
+jest.mock('../../client/index.js', () => ({
+  getApiClient: () => ({
+    cases: { bulk: mockBulk, createCase: mockCreateCase },
+  }),
+}));
+
+import './cases-bulk.js';
+import { toolRegistry } from '../../utils/registry.js';
+import { __setCaseEnumCacheForTest } from '../../utils/case-enums.js';
+
+const ok = (ids: number[]) => () => Promise.resolve({ data: { status: true, result: { ids } } });
+
+function invoke(args: Record<string, unknown>) {
+  const handler = toolRegistry.getHandler('qase_case_bulk_create')!;
+  return handler(args);
+}
+
+const sentCases = () => mockBulk.mock.calls[0][1].cases as Record<string, unknown>[];
+
+beforeAll(async () => {
+  // Real enum normalisation runs against this snapshot instead of the API.
+  await __setCaseEnumCacheForTest({
+    priority: { high: 1, medium: 2, low: 3 },
+    severity: { blocker: 1, minor: 5 },
+    automation: { 'is-not-automated': 0, 'to-be-automated': 1, automated: 2 },
+  });
+});
+
+beforeEach(() => {
+  mockBulk.mockReset().mockImplementation(ok([1, 2]));
+  mockCreateCase.mockReset();
+});
+
+describe('qase_case_bulk_create — registration', () => {
+  it('is registered as a discoverable tool', () => {
+    expect(toolRegistry.hasTool('qase_case_bulk_create')).toBe(true);
+    expect(toolRegistry.getTools().map((t) => t.name)).not.toContain('qase_case_bulk_create');
+  });
+
+  it('is findable by searching for "bulk"', () => {
+    expect(toolRegistry.searchTools('bulk').map((t) => t.name)).toContain('qase_case_bulk_create');
+  });
+});
+
+describe('qase_case_bulk_create — request shape', () => {
+  it('sends every case in a single bulk request', async () => {
+    await invoke({
+      code: 'DEMO',
+      cases: [{ title: 'Login' }, { title: 'Logout' }, { title: 'Reset password' }],
+    });
+
+    expect(mockBulk).toHaveBeenCalledTimes(1);
+    expect(mockBulk.mock.calls[0][0]).toBe('DEMO');
+    expect(sentCases().map((c) => c.title)).toEqual(['Login', 'Logout', 'Reset password']);
+  });
+
+  it('never falls back to per-case creation', async () => {
+    await invoke({ code: 'DEMO', cases: [{ title: 'A' }, { title: 'B' }] });
+    expect(mockCreateCase).not.toHaveBeenCalled();
+  });
+
+  it('returns the created count and ids', async () => {
+    mockBulk.mockImplementation(ok([220, 221, 222]));
+
+    const result = await invoke({
+      code: 'DEMO',
+      cases: [{ title: 'A' }, { title: 'B' }, { title: 'C' }],
+    });
+
+    expect(result).toEqual({ created: 3, ids: [220, 221, 222] });
+  });
+
+  it('keeps case fields such as suite_id and steps intact', async () => {
+    await invoke({
+      code: 'DEMO',
+      cases: [
+        {
+          title: 'With steps',
+          suite_id: 3,
+          steps: [{ action: 'open page', expected_result: 'page opens' }],
+        },
+      ],
+    });
+
+    expect(sentCases()[0]).toMatchObject({
+      title: 'With steps',
+      suite_id: 3,
+      steps: [{ action: 'open page', expected_result: 'page opens' }],
+    });
+  });
+});
+
+describe('qase_case_bulk_create — enum normalisation', () => {
+  it('resolves string labels to numeric IDs for every case', async () => {
+    await invoke({
+      code: 'DEMO',
+      cases: [
+        { title: 'A', priority: 'high', severity: 'blocker' },
+        { title: 'B', priority: 'low', severity: 'minor' },
+      ],
+    });
+
+    expect(sentCases()[0]).toMatchObject({ priority: 1, severity: 1 });
+    expect(sentCases()[1]).toMatchObject({ priority: 3, severity: 5 });
+  });
+
+  it('maps the automation label onto isManual/isToBeAutomated', async () => {
+    await invoke({
+      code: 'DEMO',
+      cases: [
+        { title: 'A', automation: 'automated' },
+        { title: 'B', automation: 'to-be-automated' },
+      ],
+    });
+
+    expect(sentCases()[0]).toMatchObject({ isManual: 0 });
+    expect(sentCases()[0].automation).toBeUndefined();
+    expect(sentCases()[1]).toMatchObject({ isManual: 1, isToBeAutomated: 1 });
+  });
+
+  it('accepts numeric IDs as-is', async () => {
+    await invoke({ code: 'DEMO', cases: [{ title: 'A', priority: '2' }] });
+    expect(sentCases()[0]).toMatchObject({ priority: 2 });
+  });
+});
+
+describe('qase_case_bulk_create — validation', () => {
+  it('rejects a missing `cases` argument', async () => {
+    await expect(invoke({ code: 'DEMO' })).rejects.toThrow(/cases/i);
+    expect(mockBulk).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty `cases` array', async () => {
+    await expect(invoke({ code: 'DEMO', cases: [] })).rejects.toThrow(/cases/i);
+    expect(mockBulk).not.toHaveBeenCalled();
+  });
+
+  it('rejects a case without a title', async () => {
+    await expect(
+      invoke({ code: 'DEMO', cases: [{ title: 'A' }, { priority: 'high' }] }),
+    ).rejects.toThrow(/title/i);
+    expect(mockBulk).not.toHaveBeenCalled();
+  });
+
+  it('accepts exactly 100 cases', async () => {
+    const cases = Array.from({ length: 100 }, (_, i) => ({ title: `Case ${i + 1}` }));
+    await invoke({ code: 'DEMO', cases });
+    expect(sentCases()).toHaveLength(100);
+  });
+
+  it('rejects more than 100 cases without calling the API', async () => {
+    const cases = Array.from({ length: 101 }, (_, i) => ({ title: `Case ${i + 1}` }));
+
+    await expect(invoke({ code: 'DEMO', cases })).rejects.toThrow(/100/);
+    expect(mockBulk).not.toHaveBeenCalled();
+  });
+});
+
+describe('qase_case_bulk_create — errors', () => {
+  it('surfaces API failures as tool errors', async () => {
+    mockBulk.mockImplementation(() => {
+      const error: any = new Error('Suite not found');
+      error.isAxiosError = true;
+      error.response = { status: 404, data: { errorMessage: 'Suite not found' } };
+      return Promise.reject(error);
+    });
+
+    await expect(invoke({ code: 'DEMO', cases: [{ title: 'A', suite_id: 999 }] })).rejects.toThrow(
+      /Suite not found/,
+    );
+  });
+});

--- a/src/operations-v2/write/cases-bulk.ts
+++ b/src/operations-v2/write/cases-bulk.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+import { getApiClient } from '../../client/index.js';
+import { toolRegistry, CreateAnnotation } from '../../utils/registry.js';
+import { toResultAsync, createToolError } from '../../utils/errors.js';
+import { ProjectCodeSchema } from '../../utils/validation.js';
+import { normalizeCaseEnums } from '../../utils/case-enums.js';
+import { CaseFieldsSchema, applyAutomationMapping } from './case-fields.js';
+
+const CONTEXT = 'bulk case creation';
+
+/** Qase creates the whole batch in one transaction; 100 keeps the request sane. */
+const MAX_CASES = 100;
+
+const Schema = z.object({
+  code: ProjectCodeSchema,
+  cases: z
+    .array(CaseFieldsSchema)
+    .min(1)
+    .max(MAX_CASES, `A single call creates at most ${MAX_CASES} test cases — split larger batches.`)
+    .describe(`Test cases to create, 1 to ${MAX_CASES} per call`),
+});
+
+async function handler(rawArgs: unknown) {
+  // Tool handlers get raw MCP arguments — validate here so a malformed call
+  // returns a readable error instead of a TypeError from deeper in the code.
+  const parsed = Schema.safeParse(rawArgs);
+  if (!parsed.success) {
+    const details = parsed.error.issues
+      .map((issue) => `${issue.path.join('.') || 'arguments'}: ${issue.message}`)
+      .join('; ');
+    throw createToolError(`Invalid arguments — ${details}`, CONTEXT);
+  }
+  const { code, cases } = parsed.data;
+
+  // Same enum handling as qase_case_upsert, so "high" and "blocker" work here
+  // too. System fields are cached, so this does not fan out into N API calls.
+  const normalized = await Promise.all(
+    cases.map(async (testCase) => applyAutomationMapping(await normalizeCaseEnums(testCase))),
+  );
+
+  const client = getApiClient();
+  const result = await toResultAsync(client.cases.bulk(code, { cases: normalized } as any));
+
+  return result.match(
+    (r) => {
+      const ids: number[] = r.data.result?.ids ?? [];
+      return { created: ids.length, ids };
+    },
+    (e) => {
+      throw createToolError(e, CONTEXT);
+    },
+  );
+}
+
+toolRegistry.register({
+  name: 'qase_case_bulk_create',
+  description:
+    `Create up to ${MAX_CASES} test cases in a single request. Use this instead of calling ` +
+    '`qase_case_upsert` repeatedly when importing or generating several cases at once. ' +
+    'Enum fields (priority, severity, type, etc.) accept both labels ("high", "blocker") and ' +
+    'numeric IDs. Creates only — use `qase_case_upsert` with an `id` to update an existing case. ' +
+    'Returns the IDs of the created cases in the order they were submitted.',
+  schema: Schema,
+  handler,
+  annotations: CreateAnnotation,
+  visibility: 'discoverable',
+});

--- a/src/operations-v2/write/cases.ts
+++ b/src/operations-v2/write/cases.ts
@@ -4,52 +4,7 @@ import { toolRegistry, CreateAnnotation, DeleteAnnotation } from '../../utils/re
 import { toResultAsync, createToolError } from '../../utils/errors.js';
 import { ProjectCodeSchema, IdSchema } from '../../utils/validation.js';
 import { normalizeCaseEnums } from '../../utils/case-enums.js';
-
-const stepFields = {
-  action: z.string().optional().describe('Step action (classic steps)'),
-  expected_result: z.string().optional().describe('Expected result'),
-  data: z.string().optional().describe('Test data'),
-  value: z.string().optional().describe('Gherkin scenario text (when steps_type is "gherkin")'),
-  attachments: z.array(z.string()).optional().describe('Attachment hashes'),
-};
-
-const TestStepSchema = z.object({
-  ...stepFields,
-  steps: z
-    .array(z.object(stepFields).passthrough())
-    .optional()
-    .describe('Nested substeps. Same structure as parent steps, supports further nesting.'),
-});
-
-const CaseFieldsSchema = z.object({
-  title: z.string().min(1).max(255).describe('Test case title'),
-  description: z.string().optional(),
-  preconditions: z.string().optional(),
-  postconditions: z.string().optional(),
-  severity: z.string().optional().describe('Severity label or numeric ID'),
-  priority: z
-    .string()
-    .optional()
-    .describe('Priority label or numeric ID (0=not set, 1=high, 2=medium, 3=low)'),
-  type: z.string().optional().describe('Type label or numeric ID'),
-  layer: z.string().optional().describe('Layer label or numeric ID'),
-  behavior: z.string().optional().describe('Behavior label or numeric ID'),
-  automation: z
-    .string()
-    .optional()
-    .describe(
-      'Automation status (label, slug, or numeric ID: 0=Manual / is-not-automated, 1=To be automated, 2=Automated)',
-    ),
-  status: z.string().optional().describe('Status label or numeric ID'),
-  is_flaky: z.boolean().optional(),
-  suite_id: z.number().int().positive().optional(),
-  milestone_id: z.number().int().positive().optional(),
-  steps: z.array(TestStepSchema).optional(),
-  steps_type: z.enum(['classic', 'gherkin']).optional(),
-  tags: z.array(z.string()).optional(),
-  attachments: z.array(z.string()).optional(),
-  custom_field: z.record(z.any()).optional(),
-});
+import { CaseFieldsSchema, applyAutomationMapping } from './case-fields.js';
 
 const UpsertSchema = z.object({
   code: ProjectCodeSchema,
@@ -63,40 +18,6 @@ const DeleteSchema = z.object({
   code: ProjectCodeSchema,
   id: IdSchema,
 });
-
-/**
- * Map the user-facing `automation` enum (0=Manual, 1=To be automated,
- * 2=Automated) to the current API contract (`isManual` + `isToBeAutomated`).
- * The legacy `automation` field is deprecated in qase-api-client and dropped
- * from the outbound payload.
- */
-function applyAutomationMapping(caseData: Record<string, unknown>): Record<string, unknown> {
-  const automationId = caseData.automation;
-
-  if (typeof automationId !== 'number') {
-    return caseData;
-  }
-
-  const { automation: _drop, ...rest } = caseData;
-  const mapped: Record<string, unknown> = rest;
-
-  switch (automationId) {
-    case 2: // Automated
-      mapped.isManual = 0;
-      break;
-    case 1: // To be automated
-      mapped.isManual = 1;
-      mapped.isToBeAutomated = 1;
-      break;
-    case 0: // Manual
-    default:
-      mapped.isManual = 1;
-      mapped.isToBeAutomated = 0;
-      break;
-  }
-
-  return mapped;
-}
 
 async function upsert(args: z.infer<typeof UpsertSchema>) {
   const client = getApiClient();

--- a/src/operations-v2/write/external-issues.test.ts
+++ b/src/operations-v2/write/external-issues.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Tests for qase_external_issue_link — linking cases and runs to external
+ * issue trackers (Jira Cloud / Jira Server).
+ */
+
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { setTestEnv } from '../../utils/test-helpers.js';
+
+setTestEnv();
+
+const mockCaseAttach = jest.fn();
+const mockCaseDetach = jest.fn();
+const mockRunUpdate = jest.fn();
+
+jest.mock('../../client/index.js', () => ({
+  getApiClient: () => ({
+    cases: {
+      caseAttachExternalIssue: mockCaseAttach,
+      caseDetachExternalIssue: mockCaseDetach,
+    },
+    runs: {
+      runUpdateExternalIssue: mockRunUpdate,
+    },
+  }),
+}));
+
+import './external-issues.js';
+import { toolRegistry } from '../../utils/registry.js';
+
+const ok = () => Promise.resolve({ data: { status: true, result: {} } });
+
+function invoke(args: Record<string, unknown>) {
+  const handler = toolRegistry.getHandler('qase_external_issue_link')!;
+  return handler(args);
+}
+
+describe('qase_external_issue_link — registration', () => {
+  it('is registered as a discoverable tool', () => {
+    expect(toolRegistry.hasTool('qase_external_issue_link')).toBe(true);
+    expect(toolRegistry.getTools().map((t) => t.name)).not.toContain('qase_external_issue_link');
+  });
+
+  it('is findable by searching for "jira"', () => {
+    const names = toolRegistry.searchTools('jira').map((t) => t.name);
+    expect(names).toContain('qase_external_issue_link');
+  });
+
+  it('is findable by searching for "issue"', () => {
+    const names = toolRegistry.searchTools('issue').map((t) => t.name);
+    expect(names).toContain('qase_external_issue_link');
+  });
+});
+
+describe('qase_external_issue_link — argument validation', () => {
+  beforeEach(() => {
+    mockCaseAttach.mockReset().mockImplementation(ok);
+    mockCaseDetach.mockReset().mockImplementation(ok);
+    mockRunUpdate.mockReset().mockImplementation(ok);
+  });
+
+  // The MCP server passes raw arguments straight to handlers, so the handler
+  // validates them itself instead of crashing on a missing field.
+  it('reports a missing `links` argument as a validation error', async () => {
+    await expect(
+      invoke({ code: 'DEMO', entity: 'case', action: 'attach', type: 'jira-cloud' }),
+    ).rejects.toThrow(/links/i);
+
+    expect(mockCaseAttach).not.toHaveBeenCalled();
+  });
+
+  it('reports an unknown entity as a validation error', async () => {
+    await expect(
+      invoke({
+        code: 'DEMO',
+        entity: 'defect',
+        action: 'attach',
+        type: 'jira-cloud',
+        links: [{ id: 1, issues: ['PROJ-1'] }],
+      }),
+    ).rejects.toThrow(/entity/i);
+  });
+
+  it('reports an empty `links` array as a validation error', async () => {
+    await expect(
+      invoke({ code: 'DEMO', entity: 'case', action: 'attach', type: 'jira-cloud', links: [] }),
+    ).rejects.toThrow(/links/i);
+
+    expect(mockCaseAttach).not.toHaveBeenCalled();
+  });
+});
+
+describe('qase_external_issue_link — cases', () => {
+  beforeEach(() => {
+    mockCaseAttach.mockReset().mockImplementation(ok);
+    mockCaseDetach.mockReset().mockImplementation(ok);
+    mockRunUpdate.mockReset().mockImplementation(ok);
+  });
+
+  it('attaches issues to a case via caseAttachExternalIssue', async () => {
+    await invoke({
+      code: 'DEMO',
+      entity: 'case',
+      action: 'attach',
+      type: 'jira-cloud',
+      links: [{ id: 1, issues: ['PROJ-1234'] }],
+    });
+
+    expect(mockCaseAttach).toHaveBeenCalledWith('DEMO', {
+      type: 'jira-cloud',
+      links: [{ case_id: 1, external_issues: ['PROJ-1234'] }],
+    });
+    expect(mockCaseDetach).not.toHaveBeenCalled();
+  });
+
+  it('detaches issues from a case via caseDetachExternalIssue', async () => {
+    await invoke({
+      code: 'DEMO',
+      entity: 'case',
+      action: 'detach',
+      type: 'jira-server',
+      links: [{ id: 7, issues: ['PROJ-1', 'PROJ-2'] }],
+    });
+
+    expect(mockCaseDetach).toHaveBeenCalledWith('DEMO', {
+      type: 'jira-server',
+      links: [{ case_id: 7, external_issues: ['PROJ-1', 'PROJ-2'] }],
+    });
+    expect(mockCaseAttach).not.toHaveBeenCalled();
+  });
+
+  it('sends every link in a single request', async () => {
+    await invoke({
+      code: 'DEMO',
+      entity: 'case',
+      action: 'attach',
+      type: 'jira-cloud',
+      links: [
+        { id: 1, issues: ['PROJ-1'] },
+        { id: 2, issues: ['PROJ-2'] },
+      ],
+    });
+
+    expect(mockCaseAttach).toHaveBeenCalledTimes(1);
+    expect(mockCaseAttach.mock.calls[0][1].links).toEqual([
+      { case_id: 1, external_issues: ['PROJ-1'] },
+      { case_id: 2, external_issues: ['PROJ-2'] },
+    ]);
+  });
+
+  it('rejects a case link with no issues instead of calling the API', async () => {
+    await expect(
+      invoke({
+        code: 'DEMO',
+        entity: 'case',
+        action: 'attach',
+        type: 'jira-cloud',
+        links: [{ id: 1 }],
+      }),
+    ).rejects.toThrow(/issues/i);
+
+    expect(mockCaseAttach).not.toHaveBeenCalled();
+  });
+
+  it('reports the affected case count on success', async () => {
+    const result = (await invoke({
+      code: 'DEMO',
+      entity: 'case',
+      action: 'attach',
+      type: 'jira-cloud',
+      links: [
+        { id: 1, issues: ['PROJ-1'] },
+        { id: 2, issues: ['PROJ-2'] },
+      ],
+    })) as Record<string, unknown>;
+
+    expect(result).toEqual({ success: true, entity: 'case', action: 'attach', linked: 2 });
+  });
+
+  it('surfaces API failures as tool errors', async () => {
+    mockCaseAttach.mockImplementation(() => {
+      const error: any = new Error('Issues with ids: PROJ-1 not found.');
+      error.isAxiosError = true;
+      error.response = {
+        status: 400,
+        data: { errorMessage: 'Issues with ids: PROJ-1 not found.' },
+      };
+      return Promise.reject(error);
+    });
+
+    await expect(
+      invoke({
+        code: 'DEMO',
+        entity: 'case',
+        action: 'attach',
+        type: 'jira-cloud',
+        links: [{ id: 1, issues: ['PROJ-1'] }],
+      }),
+    ).rejects.toThrow(/PROJ-1 not found/);
+  });
+});
+
+describe('qase_external_issue_link — runs', () => {
+  beforeEach(() => {
+    mockCaseAttach.mockReset().mockImplementation(ok);
+    mockCaseDetach.mockReset().mockImplementation(ok);
+    mockRunUpdate.mockReset().mockImplementation(ok);
+  });
+
+  it('attaches an issue to a run via runUpdateExternalIssue', async () => {
+    await invoke({
+      code: 'DEMO',
+      entity: 'run',
+      action: 'attach',
+      type: 'jira-cloud',
+      links: [{ id: 400, issues: ['PROJ-1234'] }],
+    });
+
+    expect(mockRunUpdate).toHaveBeenCalledWith('DEMO', {
+      type: 'jira-cloud',
+      links: [{ run_id: 400, external_issue: 'PROJ-1234' }],
+    });
+  });
+
+  it('detaches a run link by sending external_issue: null', async () => {
+    await invoke({
+      code: 'DEMO',
+      entity: 'run',
+      action: 'detach',
+      type: 'jira-cloud',
+      links: [{ id: 400 }],
+    });
+
+    expect(mockRunUpdate).toHaveBeenCalledWith('DEMO', {
+      type: 'jira-cloud',
+      links: [{ run_id: 400, external_issue: null }],
+    });
+  });
+
+  it('rejects attaching more than one issue to a run', async () => {
+    await expect(
+      invoke({
+        code: 'DEMO',
+        entity: 'run',
+        action: 'attach',
+        type: 'jira-cloud',
+        links: [{ id: 400, issues: ['PROJ-1', 'PROJ-2'] }],
+      }),
+    ).rejects.toThrow(/only one/i);
+
+    expect(mockRunUpdate).not.toHaveBeenCalled();
+  });
+
+  it('rejects attaching to a run without an issue', async () => {
+    await expect(
+      invoke({
+        code: 'DEMO',
+        entity: 'run',
+        action: 'attach',
+        type: 'jira-cloud',
+        links: [{ id: 400 }],
+      }),
+    ).rejects.toThrow(/issues/i);
+
+    expect(mockRunUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/src/operations-v2/write/external-issues.ts
+++ b/src/operations-v2/write/external-issues.ts
@@ -1,0 +1,125 @@
+import { z } from 'zod';
+import { getApiClient } from '../../client/index.js';
+import { toolRegistry, UpdateAnnotation } from '../../utils/registry.js';
+import { toResultAsync, createToolError } from '../../utils/errors.js';
+import { ProjectCodeSchema, IdSchema } from '../../utils/validation.js';
+
+const CONTEXT = 'external issue link operation';
+
+const LinkSchema = z.object({
+  id: IdSchema.describe('Test case ID (entity="case") or test run ID (entity="run")'),
+  issues: z
+    .array(z.string().min(1))
+    .optional()
+    .describe(
+      'External issue keys, e.g. ["PROJ-1234"]. Required for cases (attach and detach) and ' +
+        'for attaching to a run — a run accepts exactly one issue. Omit when detaching a run.',
+    ),
+});
+
+const Schema = z.object({
+  code: ProjectCodeSchema,
+  entity: z.enum(['case', 'run']).describe('Entity to link — test case or test run'),
+  action: z
+    .enum(['attach', 'detach'])
+    .describe('attach creates the link, detach removes it (for runs, clears the single link)'),
+  type: z
+    .enum(['jira-cloud', 'jira-server'])
+    .describe('Issue tracker integration configured for the project'),
+  links: z.array(LinkSchema).min(1).describe('Entities to link, processed in a single API request'),
+});
+
+type Args = z.infer<typeof Schema>;
+
+function requireIssues(link: Args['links'][number], entity: string): string[] {
+  if (!link.issues?.length) {
+    throw createToolError(
+      `No issues provided for ${entity} ${link.id} — "issues" must contain at least one external issue key (e.g. "PROJ-1234").`,
+      CONTEXT,
+    );
+  }
+  return link.issues;
+}
+
+async function linkCases(args: Args) {
+  const client = getApiClient();
+  const payload = {
+    type: args.type,
+    links: args.links.map((link) => ({
+      case_id: link.id,
+      external_issues: requireIssues(link, 'case'),
+    })),
+  };
+
+  const call =
+    args.action === 'attach'
+      ? client.cases.caseAttachExternalIssue(args.code, payload as any)
+      : client.cases.caseDetachExternalIssue(args.code, payload as any);
+
+  return toResultAsync(call);
+}
+
+async function linkRuns(args: Args) {
+  const client = getApiClient();
+  const payload = {
+    type: args.type,
+    links: args.links.map((link) => {
+      if (args.action === 'detach') {
+        return { run_id: link.id, external_issue: null };
+      }
+
+      const issues = requireIssues(link, 'run');
+      if (issues.length > 1) {
+        throw createToolError(
+          `A test run can have only one external issue link — ${issues.length} issues provided for run ${link.id}.`,
+          CONTEXT,
+        );
+      }
+
+      return { run_id: link.id, external_issue: issues[0] };
+    }),
+  };
+
+  return toResultAsync(client.runs.runUpdateExternalIssue(args.code, payload as any));
+}
+
+async function handler(rawArgs: unknown) {
+  // Tool handlers get raw MCP arguments — validate here so a malformed call
+  // returns a readable error instead of a TypeError from deeper in the code.
+  const parsed = Schema.safeParse(rawArgs);
+  if (!parsed.success) {
+    const details = parsed.error.issues
+      .map((issue) => `${issue.path.join('.') || 'arguments'}: ${issue.message}`)
+      .join('; ');
+    throw createToolError(`Invalid arguments — ${details}`, CONTEXT);
+  }
+  const args = parsed.data;
+
+  const result = args.entity === 'case' ? await linkCases(args) : await linkRuns(args);
+
+  return result.match(
+    () => ({
+      success: true,
+      entity: args.entity,
+      action: args.action,
+      linked: args.links.length,
+    }),
+    (e) => {
+      throw createToolError(e, CONTEXT);
+    },
+  );
+}
+
+toolRegistry.register({
+  name: 'qase_external_issue_link',
+  description:
+    'Link or unlink test cases and test runs to issues in an external tracker (Jira Cloud or ' +
+    'Jira Server). Use `entity` to choose between cases and runs and `action` to attach or ' +
+    'detach. A test case can be linked to several issues; a test run can have only one link, ' +
+    'and attaching a new issue replaces the previous one. Read linked issues back with ' +
+    '`qase_get` (entity "case" or "run").',
+  schema: Schema,
+  handler,
+  annotations: UpdateAnnotation,
+  visibility: 'discoverable',
+});

--- a/src/smoke.test.ts
+++ b/src/smoke.test.ts
@@ -312,6 +312,7 @@ describe('Tool Smoke Tests', () => {
       'qql_search',
       'qql_help',
       'qase_case_upsert',
+      'qase_case_bulk_create',
       'qase_case_delete',
       'qase_run_upsert',
       'qase_run_complete',
@@ -369,6 +370,7 @@ describe('Tool Smoke Tests', () => {
   it('discoverable tools are NOT in getTools() by default', () => {
     const coreTools = toolRegistry.getTools().map((t) => t.name);
     const discoverableTools = [
+      'qase_case_bulk_create',
       'qase_case_delete',
       'qase_suite_upsert',
       'qase_suite_delete',

--- a/src/smoke.test.ts
+++ b/src/smoke.test.ts
@@ -332,6 +332,7 @@ describe('Tool Smoke Tests', () => {
       'qase_environment_delete',
       'qase_attachment_upload',
       'qase_attachment_delete',
+      'qase_external_issue_link',
       'qase_api',
       'qase_ci_report',
       'qase_triage_defect',
@@ -385,6 +386,7 @@ describe('Tool Smoke Tests', () => {
       'qase_defect_delete',
       'qase_attachment_upload',
       'qase_attachment_delete',
+      'qase_external_issue_link',
     ];
     for (const name of discoverableTools) {
       expect(coreTools).not.toContain(name);


### PR DESCRIPTION
## Summary

Adds external issue linking, restores bulk test case creation, and fixes tool discovery activation. Released as `2.0.1`.

Related: #64, #65 — left open on purpose; they will be closed once the change is live in production.

## `qase_external_issue_link`

Links and unlinks test cases and test runs to issues in an external tracker, wrapping three REST endpoints that had no tool coverage:

- `POST /v1/case/{code}/external-issue/attach`
- `POST /v1/case/{code}/external-issue/detach`
- `POST /v1/run/{code}/external-issue`

One tool covers both entities and both directions through `entity` (`case` / `run`) and `action` (`attach` / `detach`), and sends every link in a single request:

```jsonc
{
  "code": "DEMO",
  "entity": "case",
  "action": "attach",
  "type": "jira-cloud",
  "links": [{ "id": 1, "issues": ["PROJ-1234"] }]
}
```

A test case can hold several links; a test run holds exactly one, so attaching a new issue replaces the previous one and detaching sends `external_issue: null`. Passing two issues for a run is rejected before the request leaves the server. `type` is restricted to `jira-cloud` and `jira-server` — the attach endpoint rejects every other tracker, verified against the live API.

## `qase_get` now returns linked issues

The API omits `external_issues` (cases) and `external_issue` (runs) unless the request asks for them via `include`, which made a link impossible to verify without opening the web UI. `qase_get` now requests them by default for cases and runs, and accepts an `include` parameter to override that. If a deployment rejects the default value, the request is retried without it so a plain get never breaks; an `include` passed by the caller is never dropped silently.

## `qase_case_bulk_create`

v1 shipped `bulk_create_cases`; the consolidation from 83 tools to 29 dropped it, leaving one `qase_case_upsert` call per case — 50 cases meant 50 round trips, while the SDK's `cases.bulk` sat unused. The new tool takes 1 to 100 cases and creates them in a single request, returning the new IDs in submission order.

Kept separate from `qase_case_upsert` rather than accepting an array there: upsert requires `title` at the top level, and branching on "one case or many" would force that field to become optional and weaken validation on the single-case path. The bulk endpoint also creates only, so it does not share upsert semantics.

Unlike the v1 tool, every case goes through the same enum normalisation as `qase_case_upsert`, so `priority: "high"` and `severity: "blocker"` work here too — v1 rejected string labels despite documenting them (#13). System fields are cached, so normalising N cases does not fan out into N API calls.

`CaseFieldsSchema`, `TestStepSchema`, and `applyAutomationMapping` moved out of `write/cases.ts` into `write/case-fields.ts` so both tools share one definition of the case body.

## Fix: tool discovery never activated anything

`qase_discover_tools` declares `activate` with a Zod default of `true`, but tool handlers receive raw MCP arguments — the schema never runs — so the default never applied. A call without an explicit `activate: true` found matching tools and reported them, yet left every one of them inactive and therefore absent from the client's tool list. The default is now applied in the handler.

The same gap is why both new tools validate their own input with `safeParse`: without it, a missing `links` or `cases` argument surfaced as a TypeError instead of a readable message.

## Testing

42 new unit tests, written before the implementation; 413 pass in total.

End-to-end against the live API through the built MCP server over stdio:

- discovery hides the new tools until `qase_discover_tools` activates them, then they appear in `tools/list`
- `qase_get` returns real links on cases that have them, with and without field projection
- detaching a run link and detaching a case link both succeed against the API; attaching reaches Jira and returns its "issue not found" error, confirming route and payload
- bulk creation of three cases in one call, read back to confirm `priority: high → 1`, `severity: blocker → 1`, `automation: automated → isManual: false`, and that steps survive
- the 100-case limit, a case without a title, and an unsupported tracker are all rejected before any request is sent

All test data created during these runs was deleted afterwards.

## Docs

`docs/tools.md`, `README.md` tool counts (30 → 32), and `docs/migration.md`, where the `bulk_create_cases` row now points at the new tool instead of "call once per case".
