### PR TITLE
feat: reference shared steps from test cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.2]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Shared steps can now be referenced from a test case.** `qase_case_upsert` and `qase_case_bulk_create` document a `shared` property on step objects, taking the hash returned by `qase_shared_step_upsert`; `action` is not required for such a step and nesting works at any depth. `shared_step_hash` — the name the API uses when reading a case back — is accepted as an alias and translated to `shared` before the request is sent, so the field seen on read now also works on write. ([#66](https://github.com/qase-tms/qase-mcp-server/issues/66))
+
+### Changed
+
+- Updated `qase-api-client` to 1.1.13, which adds `shared` to the test step create model.
+
 ## [2.0.1]
 
 ### Added

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -34,8 +34,8 @@ Every tool's schema uses "label or numeric ID" strings for Qase's configurable e
 
 | Tool | Description | Key params | Visibility |
 | --- | --- | --- | --- |
-| `qase_case_upsert` | Create or update a test case. If `id` is provided, updates the existing case; if omitted, creates a new one. Enum fields (priority, severity, type, etc.) accept both labels ("high", "blocker") and numeric IDs — the server normalizes automatically. | `code`, `id` (optional), `title` (1-255 chars), `description`, `preconditions`, `postconditions`, `severity`, `priority`, `type`, `layer`, `behavior`, `automation`, `status` (all label-or-ID strings), `is_flaky`, `suite_id`, `milestone_id`, `steps` (array, supports nesting), `steps_type` (enum: classic, gherkin), `tags`, `attachments`, `custom_field` | core |
-| `qase_case_bulk_create` | Create up to 100 test cases in a single request. Use instead of calling `qase_case_upsert` repeatedly when importing or generating several cases at once. Enum fields accept labels or numeric IDs. Creates only — use `qase_case_upsert` with an `id` to update. Returns the IDs of the created cases in submission order. | `code`, `cases` (array, 1-100 — same fields as `qase_case_upsert` without `id`) | discoverable |
+| `qase_case_upsert` | Create or update a test case. If `id` is provided, updates the existing case; if omitted, creates a new one. Enum fields (priority, severity, type, etc.) accept both labels ("high", "blocker") and numeric IDs — the server normalizes automatically. | `code`, `id` (optional), `title` (1-255 chars), `description`, `preconditions`, `postconditions`, `severity`, `priority`, `type`, `layer`, `behavior`, `automation`, `status` (all label-or-ID strings), `is_flaky`, `suite_id`, `milestone_id`, `steps` (array, supports nesting; a step may reference a shared step via `shared` — the shared step hash — instead of `action`), `steps_type` (enum: classic, gherkin), `tags`, `attachments`, `custom_field` | core |
+| `qase_case_bulk_create` | Create up to 100 test cases in a single request. Use instead of calling `qase_case_upsert` repeatedly when importing or generating several cases at once. Enum fields accept labels or numeric IDs. Creates only — use `qase_case_upsert` with an `id` to update. Returns the IDs of the created cases in submission order. | `code`, `cases` (array, 1-100 — same fields as `qase_case_upsert` without `id`, including `shared` step references) | discoverable |
 | `qase_case_delete` | Delete a test case by project code and case ID. | `code`, `id` | discoverable |
 | `qase_defect_upsert` | Create or update a defect. If `id` is provided, updates (including status changes and resolve). If omitted, creates a new defect. Set `status: "resolved"` to resolve an existing defect. | `code`, `id` (optional), `title` (1-255 chars), `actual_result`, `severity` (enum, see [below](#case-enum-values)), `status` (enum: open, in_progress, resolved, invalid), `tags`, `attachments`, `custom_field` | core |
 | `qase_defect_delete` | Delete a defect by project code and defect ID. | `code`, `id` | discoverable |
@@ -59,6 +59,9 @@ Every tool's schema uses "label or numeric ID" strings for Qase's configurable e
 | `qase_external_issue_link` | Link or unlink test cases and test runs to issues in an external tracker (Jira Cloud or Jira Server). A case can be linked to several issues; a run can have only one link, and attaching a new issue replaces the previous one. Detaching a run clears its link. Read linked issues back with `qase_get`. | `code`, `entity` (enum: case, run), `action` (enum: attach, detach), `type` (enum: jira-cloud, jira-server), `links` (array: `id`, `issues` — issue keys such as `PROJ-1234`) | discoverable |
 
 </details>
+
+To insert a shared step into a test case, pass its hash as `shared` on a step object in `qase_case_upsert` or `qase_case_bulk_create`: `{"steps": [{"shared": "<hash>"}]}`. `action` is not required for such a step, and nesting is supported. The read side of the API reports the link as `shared_step_hash`; that spelling is accepted on write too and is translated automatically.
+
 
 ## Composite tools
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "jose": "^6.1.3",
         "lru-cache": "^11.3.5",
         "neverthrow": "^8.2.0",
-        "qase-api-client": "^1.1.10",
+        "qase-api-client": "^1.1.13",
         "zod": "^3.24.2",
         "zod-to-json-schema": "^3.24.3"
       },
@@ -6668,12 +6668,12 @@
       "license": "MIT"
     },
     "node_modules/qase-api-client": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/qase-api-client/-/qase-api-client-1.1.12.tgz",
-      "integrity": "sha512-wzN6P0oFfA1Gi7Gr8b13TlPqJeGOkopkPiY8IGLw6EfdqKVf1mNrzr/mI5V2ZikiLta0MVbLi7s3zZLAf+9SxQ==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/qase-api-client/-/qase-api-client-1.1.13.tgz",
+      "integrity": "sha512-5dnBXuu7zq1f5f8o3NR6Wd5E9mtgAO6RhPPB5PvU1F7N/mKH3vlDI386T5YvNVa0m7Du2HJdAb9gnqV8+W7xjQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "axios": "^1.16.0",
+        "axios": "^1.18.1",
         "axios-retry": "^4.5.0"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qase/mcp-server",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qase/mcp-server",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "jose": "^6.1.3",
     "lru-cache": "^11.3.5",
     "neverthrow": "^8.2.0",
-    "qase-api-client": "^1.1.10",
+    "qase-api-client": "^1.1.13",
     "zod": "^3.24.2",
     "zod-to-json-schema": "^3.24.3"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qase/mcp-server",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "mcpName": "io.qase/mcp-server",
   "description": "Official MCP server for Qase Test Management Platform",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/qase-tms/qase-mcp-server",
     "source": "github"
   },
-  "version": "2.0.1",
+  "version": "2.0.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@qase/mcp-server",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "transport": {
         "type": "stdio"
       },

--- a/src/operations-v2/write/case-fields.ts
+++ b/src/operations-v2/write/case-fields.ts
@@ -9,11 +9,28 @@
 import { z } from 'zod';
 
 const stepFields = {
-  action: z.string().optional().describe('Step action (classic steps)'),
+  action: z
+    .string()
+    .optional()
+    .describe('Step action (classic steps). Not needed when `shared` is set.'),
   expected_result: z.string().optional().describe('Expected result'),
   data: z.string().optional().describe('Test data'),
   value: z.string().optional().describe('Gherkin scenario text (when steps_type is "gherkin")'),
   attachments: z.array(z.string()).optional().describe('Attachment hashes'),
+  shared: z
+    .string()
+    .optional()
+    .describe(
+      'Hash of an existing shared step to insert at this position, from `qase_shared_step_upsert`. ' +
+        'The step then reuses that shared step instead of defining its own content, so `action` ' +
+        'can be omitted. Reading the case back reports the link as `shared_step_hash`.',
+    ),
+  shared_step_hash: z
+    .string()
+    .optional()
+    .describe(
+      'Alias for `shared` — the name used when reading a case. Sent to the API as `shared`.',
+    ),
 };
 
 export const TestStepSchema = z.object({
@@ -53,6 +70,35 @@ export const CaseFieldsSchema = z.object({
   attachments: z.array(z.string()).optional(),
   custom_field: z.record(z.any()).optional(),
 });
+
+/**
+ * Rewrite `shared_step_hash` to `shared` throughout a step tree.
+ *
+ * The API links a step to a shared step through `shared`, but reports the same
+ * link back as `shared_step_hash` — so that is the name callers reach for after
+ * reading a case, and sending it produces a confusing "Action field is
+ * required". Accept both spellings and send the one the API understands.
+ */
+export function resolveSharedStepRefs(steps: unknown): unknown {
+  if (!Array.isArray(steps)) return steps;
+
+  return steps.map((step) => {
+    if (typeof step !== 'object' || step === null) return step;
+
+    const { shared_step_hash: alias, ...rest } = step as Record<string, unknown>;
+    const resolved: Record<string, unknown> = rest;
+
+    if (alias !== undefined && resolved.shared === undefined) {
+      resolved.shared = alias;
+    }
+
+    if (resolved.steps !== undefined) {
+      resolved.steps = resolveSharedStepRefs(resolved.steps);
+    }
+
+    return resolved;
+  });
+}
 
 /**
  * Map the user-facing `automation` enum (0=Manual, 1=To be automated,

--- a/src/operations-v2/write/cases-bulk.test.ts
+++ b/src/operations-v2/write/cases-bulk.test.ts
@@ -102,6 +102,40 @@ describe('qase_case_bulk_create — request shape', () => {
   });
 });
 
+describe('qase_case_bulk_create — shared step references', () => {
+  const HASH = '9f8f0ce2660523589bfd34889c47e0647a1460c0';
+
+  it('passes `shared` through for each case', async () => {
+    await invoke({
+      code: 'DEMO',
+      cases: [
+        { title: 'A', steps: [{ shared: HASH }] },
+        { title: 'B', steps: [{ action: 'inline' }] },
+      ],
+    });
+
+    expect(sentCases()[0].steps).toEqual([{ shared: HASH }]);
+    expect(sentCases()[1].steps).toEqual([{ action: 'inline' }]);
+  });
+
+  it('translates the `shared_step_hash` alias, including nested steps', async () => {
+    await invoke({
+      code: 'DEMO',
+      cases: [
+        {
+          title: 'A',
+          steps: [{ shared_step_hash: HASH }, { action: 'p', steps: [{ shared_step_hash: HASH }] }],
+        },
+      ],
+    });
+
+    expect(sentCases()[0].steps).toEqual([
+      { shared: HASH },
+      { action: 'p', steps: [{ shared: HASH }] },
+    ]);
+  });
+});
+
 describe('qase_case_bulk_create — enum normalisation', () => {
   it('resolves string labels to numeric IDs for every case', async () => {
     await invoke({

--- a/src/operations-v2/write/cases-bulk.ts
+++ b/src/operations-v2/write/cases-bulk.ts
@@ -4,7 +4,7 @@ import { toolRegistry, CreateAnnotation } from '../../utils/registry.js';
 import { toResultAsync, createToolError } from '../../utils/errors.js';
 import { ProjectCodeSchema } from '../../utils/validation.js';
 import { normalizeCaseEnums } from '../../utils/case-enums.js';
-import { CaseFieldsSchema, applyAutomationMapping } from './case-fields.js';
+import { CaseFieldsSchema, applyAutomationMapping, resolveSharedStepRefs } from './case-fields.js';
 
 const CONTEXT = 'bulk case creation';
 
@@ -35,7 +35,13 @@ async function handler(rawArgs: unknown) {
   // Same enum handling as qase_case_upsert, so "high" and "blocker" work here
   // too. System fields are cached, so this does not fan out into N API calls.
   const normalized = await Promise.all(
-    cases.map(async (testCase) => applyAutomationMapping(await normalizeCaseEnums(testCase))),
+    cases.map(async (testCase) => {
+      const mapped = applyAutomationMapping(await normalizeCaseEnums(testCase));
+      if (mapped.steps !== undefined) {
+        mapped.steps = resolveSharedStepRefs(mapped.steps);
+      }
+      return mapped;
+    }),
   );
 
   const client = getApiClient();

--- a/src/operations-v2/write/cases.test.ts
+++ b/src/operations-v2/write/cases.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for qase_case_upsert — focused on referencing shared steps from a case.
+ *
+ * The API links a step to a shared step through the `shared` property holding
+ * the shared step hash; on read the same link comes back as
+ * `shared_step_hash`, which is what callers tend to try first.
+ */
+
+import { describe, it, expect, beforeEach, beforeAll } from '@jest/globals';
+import { setTestEnv } from '../../utils/test-helpers.js';
+
+setTestEnv();
+
+const mockCreateCase = jest.fn();
+const mockUpdateCase = jest.fn();
+
+jest.mock('../../client/index.js', () => ({
+  getApiClient: () => ({
+    cases: { createCase: mockCreateCase, updateCase: mockUpdateCase },
+  }),
+}));
+
+import './cases.js';
+import { toolRegistry } from '../../utils/registry.js';
+import { __setCaseEnumCacheForTest } from '../../utils/case-enums.js';
+
+const HASH = '9f8f0ce2660523589bfd34889c47e0647a1460c0';
+
+function invoke(args: Record<string, unknown>) {
+  const handler = toolRegistry.getHandler('qase_case_upsert')!;
+  return handler(args);
+}
+
+/** Steps as they were sent to the API on the last create call. */
+const sentSteps = () => mockCreateCase.mock.calls[0][1].steps as Record<string, unknown>[];
+
+beforeAll(async () => {
+  await __setCaseEnumCacheForTest({ priority: { high: 1 } });
+});
+
+beforeEach(() => {
+  mockCreateCase
+    .mockReset()
+    .mockImplementation(() => Promise.resolve({ data: { status: true, result: { id: 1 } } }));
+  mockUpdateCase
+    .mockReset()
+    .mockImplementation(() => Promise.resolve({ data: { status: true, result: { id: 1 } } }));
+});
+
+describe('qase_case_upsert — shared step references', () => {
+  it('passes `shared` through on a top-level step', async () => {
+    await invoke({ code: 'DEMO', title: 'Case', steps: [{ shared: HASH }] });
+    expect(sentSteps()[0]).toEqual({ shared: HASH });
+  });
+
+  it('accepts a step that has only `shared`, without action text', async () => {
+    await invoke({ code: 'DEMO', title: 'Case', steps: [{ shared: HASH }] });
+    expect(mockCreateCase).toHaveBeenCalled();
+  });
+
+  it('passes `shared` through on a nested step', async () => {
+    await invoke({
+      code: 'DEMO',
+      title: 'Case',
+      steps: [{ action: 'parent', steps: [{ shared: HASH }] }],
+    });
+
+    expect(sentSteps()[0]).toMatchObject({
+      action: 'parent',
+      steps: [{ shared: HASH }],
+    });
+  });
+
+  it('mixes shared and inline steps in order', async () => {
+    await invoke({
+      code: 'DEMO',
+      title: 'Case',
+      steps: [{ shared: HASH }, { action: 'Regular step' }],
+    });
+
+    expect(sentSteps()).toEqual([{ shared: HASH }, { action: 'Regular step' }]);
+  });
+});
+
+describe('qase_case_upsert — shared_step_hash alias', () => {
+  // The read side of the API reports the link as `shared_step_hash`, so callers
+  // reach for that name on write. The API only accepts `shared`.
+  it('translates `shared_step_hash` into `shared`', async () => {
+    await invoke({ code: 'DEMO', title: 'Case', steps: [{ shared_step_hash: HASH }] });
+
+    expect(sentSteps()[0]).toEqual({ shared: HASH });
+  });
+
+  it('translates the alias on nested steps too', async () => {
+    await invoke({
+      code: 'DEMO',
+      title: 'Case',
+      steps: [{ action: 'parent', steps: [{ shared_step_hash: HASH }] }],
+    });
+
+    expect(sentSteps()[0]).toMatchObject({ steps: [{ shared: HASH }] });
+  });
+
+  it('never sends shared_step_hash to the API', async () => {
+    await invoke({ code: 'DEMO', title: 'Case', steps: [{ shared_step_hash: HASH }] });
+
+    expect(JSON.stringify(sentSteps())).not.toContain('shared_step_hash');
+  });
+
+  it('prefers `shared` when both names are given', async () => {
+    await invoke({
+      code: 'DEMO',
+      title: 'Case',
+      steps: [{ shared: HASH, shared_step_hash: 'other-hash' }],
+    });
+
+    expect(sentSteps()[0]).toEqual({ shared: HASH });
+  });
+});
+
+describe('qase_case_upsert — regressions', () => {
+  it('leaves ordinary steps untouched', async () => {
+    await invoke({
+      code: 'DEMO',
+      title: 'Case',
+      steps: [{ action: 'open page', expected_result: 'page opens', data: 'none' }],
+    });
+
+    expect(sentSteps()[0]).toEqual({
+      action: 'open page',
+      expected_result: 'page opens',
+      data: 'none',
+    });
+  });
+
+  it('still normalises enum labels', async () => {
+    await invoke({ code: 'DEMO', title: 'Case', priority: 'high' });
+    expect(mockCreateCase.mock.calls[0][1]).toMatchObject({ priority: 1 });
+  });
+
+  it('updates an existing case when id is given', async () => {
+    await invoke({ code: 'DEMO', id: 7, title: 'Case', steps: [{ shared: HASH }] });
+
+    expect(mockUpdateCase).toHaveBeenCalled();
+    expect(mockUpdateCase.mock.calls[0][2].steps).toEqual([{ shared: HASH }]);
+    expect(mockCreateCase).not.toHaveBeenCalled();
+  });
+});

--- a/src/operations-v2/write/cases.ts
+++ b/src/operations-v2/write/cases.ts
@@ -4,7 +4,7 @@ import { toolRegistry, CreateAnnotation, DeleteAnnotation } from '../../utils/re
 import { toResultAsync, createToolError } from '../../utils/errors.js';
 import { ProjectCodeSchema, IdSchema } from '../../utils/validation.js';
 import { normalizeCaseEnums } from '../../utils/case-enums.js';
-import { CaseFieldsSchema, applyAutomationMapping } from './case-fields.js';
+import { CaseFieldsSchema, applyAutomationMapping, resolveSharedStepRefs } from './case-fields.js';
 
 const UpsertSchema = z.object({
   code: ProjectCodeSchema,
@@ -23,6 +23,10 @@ async function upsert(args: z.infer<typeof UpsertSchema>) {
   const client = getApiClient();
   const { code, id, ...data } = args;
   const normalized = applyAutomationMapping(await normalizeCaseEnums(data));
+
+  if (normalized.steps !== undefined) {
+    normalized.steps = resolveSharedStepRefs(normalized.steps);
+  }
 
   const result = await toResultAsync(
     id


### PR DESCRIPTION
Lets a test case reference a shared step. Released as `2.0.2`.

Related: #66 — kept open until this is live in production.

## What changed

The case endpoints link a step to a shared step through a `shared` property holding the shared step hash, but the field was undocumented — missing from the OpenAPI spec, the generated client, and our tool schemas. An agent only sees a tool's `inputSchema`, so an undescribed field is one nobody uses; callers concluded shared steps could not be attached through the API at all.

- `shared` is now described on step objects in `qase_case_upsert` and `qase_case_bulk_create`. `action` is not required alongside it, and nesting works at any depth.
- `shared_step_hash` is accepted as an alias. That is the name the API reports when reading a case back, so it is what callers try first on write — and it failed with a misleading `Action field is required`. It is rewritten to `shared` throughout the step tree before the request is sent.
- `qase-api-client` bumped to 1.1.13, which adds `shared` to `TestStepCreate` following the spec update.

```jsonc
{ "code": "DEMO", "title": "Login flow", "steps": [{ "shared": "<hash>" }, { "action": "Regular step" }] }
```

## Testing

15 new unit tests (426 total). Verified end-to-end against the live API through the built MCP server: `shared` and the alias both create the link, on top-level and nested steps, in single and bulk creation; an unknown hash is rejected by the API. Test data was deleted afterwards.

## Out of scope

`shared_id`, the numeric form, is deliberately not supported: it bypasses ownership validation on the backend. Reported separately.
