### PR TITLE
chore: prep for MCP spec 2026-07-28 (v2.0.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3]
+
+### Changed
+
+- `tools/list` and `prompts/list` now return entries in deterministic, name-sorted order instead of registration order, per the MCP spec's guidance for improving client-side caching and LLM prompt cache hit rates.
+- The Streamable HTTP transport now allows the `Mcp-Method` and `Mcp-Name` request headers via CORS, ahead of client adoption of MCP spec [2026-07-28](https://blog.modelcontextprotocol.io/posts/2026-07-28/).
+
 ## [2.0.2]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qase/mcp-server",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qase/mcp-server",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qase/mcp-server",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "mcpName": "io.qase/mcp-server",
   "description": "Official MCP server for Qase Test Management Platform",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/qase-tms/qase-mcp-server",
     "source": "github"
   },
-  "version": "2.0.2",
+  "version": "2.0.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@qase/mcp-server",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "transport": {
         "type": "stdio"
       },

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -221,13 +221,15 @@ const prompts: PromptDef[] = [
   },
 ];
 
-/** Get all prompt definitions for ListPrompts */
+/** Get all prompt definitions for ListPrompts, in deterministic (name-sorted) order */
 export function listPrompts() {
-  return prompts.map((p) => ({
-    name: p.name,
-    description: p.description,
-    arguments: p.arguments,
-  }));
+  return [...prompts]
+    .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+    .map((p) => ({
+      name: p.name,
+      description: p.description,
+      arguments: p.arguments,
+    }));
 }
 
 /** Build prompt messages for GetPrompt */

--- a/src/transports/streamableHttp.ts
+++ b/src/transports/streamableHttp.ts
@@ -56,7 +56,12 @@ export function setupStreamableHttpTransport(
   app.use((req, res, next) => {
     res.header('Access-Control-Allow-Origin', process.env.CORS_ORIGIN || '*');
     res.header('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
-    res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization, mcp-session-id');
+    // Mcp-Method / Mcp-Name are required request headers as of MCP spec 2026-07-28
+    // (gateway routing without body parsing) — allow them ahead of client adoption.
+    res.header(
+      'Access-Control-Allow-Headers',
+      'Content-Type, Authorization, mcp-session-id, Mcp-Method, Mcp-Name',
+    );
     // Expose auth challenge + session id so browser-based MCP clients (Inspector,
     // Claude.ai web) can read them from cross-origin responses. Without this the
     // 401 WWW-Authenticate challenge is invisible to client JS and OAuth never starts.

--- a/src/utils/registry.test.ts
+++ b/src/utils/registry.test.ts
@@ -254,7 +254,7 @@ describe('ToolRegistry', () => {
       expect(active).toEqual(['core_a', 'core_c']);
 
       const all = registry.getAllTools().map((t) => t.name);
-      expect(all).toEqual(['core_a', 'disc_b', 'core_c']);
+      expect(all).toEqual(['core_a', 'core_c', 'disc_b']);
     });
   });
 

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -136,7 +136,9 @@ export class ToolRegistry {
    * Used by the ListToolsRequestSchema handler
    */
   getTools(): Tool[] {
-    return Array.from(this.tools.values()).filter((t) => this.activeTools.has(t.name));
+    return Array.from(this.tools.values())
+      .filter((t) => this.activeTools.has(t.name))
+      .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
   }
 
   /**
@@ -144,7 +146,9 @@ export class ToolRegistry {
    * Used for discovery search and testing.
    */
   getAllTools(): Tool[] {
-    return Array.from(this.tools.values());
+    return Array.from(this.tools.values()).sort((a, b) =>
+      a.name < b.name ? -1 : a.name > b.name ? 1 : 0,
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary
- Return `tools/list` and `prompts/list` in deterministic, name-sorted order instead of registration order, per the [2026-07-28 spec](https://blog.modelcontextprotocol.io/posts/2026-07-28/)'s guidance for client-side caching / LLM prompt cache hits.
- Allow `Mcp-Method` / `Mcp-Name` request headers via CORS on the Streamable HTTP transport, ahead of client adoption.
- Bump version to 2.0.3, update CHANGELOG.

Note: the bulk of 2026-07-28 (stateless core, `server/discover`, MRTR, `resultType`, cacheable-list fields) isn't adopted yet — the TS SDK (npm latest 1.30.0) doesn't implement it, and current clients (Claude, Cursor, Codex) still negotiate 2025-11-25/2025-06-18. These two changes are safe, backward-compatible steps only.

## Test plan
- [x] `npm run build`
- [x] `npm test` (427 tests, 1 pre-existing skip, all green)
- [x] `npm run lint` (0 errors, pre-existing warnings only)