### PR TITLE
fix: schema-level correctness fixes across triage, project context, and QQL (v2.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.4]
 
+### Breaking Changes
+
+- **`qase_triage_defect` no longer accepts `run_id` or `failed_result_ids`.** Both were read from the arguments and then ignored — the tool only ever created the defect. `POST /v1/defect/{code}` accepts `title`, `actual_result`, `severity`, `milestone_id`, `attachments`, `custom_field`, and `tags`; there is no field for runs or results, and no endpoint to attach them afterwards. The `runs`/`results` arrays visible on a defect are populated by the test runner when a result is reported as a defect. Reference failing results in `actual_result` instead.
+- **`qase_triage_defect` now requires `actual_result` and `severity`**, which the API has always required. Marking them optional produced requests the API rejects, with nothing in the tool contract to warn about it.
+
 ### Fixed
 
+- **`qase_triage_defect` reported linking it never performed.** The summary printed `Linked results: N` and the structured result carried `linked_results: N`, both derived from the length of the ignored `failed_result_ids` argument — so the tool reported work it had not done. Both are gone, along with `linked_results` from `TriageDefectOutput`. The tool description no longer promises "create defect → link to failing tests" either.
 - **`qase_project_context` no longer truncates collections silently.** Suites, milestones, environments, custom fields, and users were each capped at the first 100 entities with no indication in the response — a project with 2 711 suites reported "Suites: 100" and the consumer had no way to learn it was seeing 3.7% of the data. The result now carries a `coverage` field with `{ total, loaded, truncated }` per collection, and the summary spells out `100 of 2711 ⚠️ truncated` plus how to get the rest. The "Top-level suites (N of M total)" header no longer presents the loaded slice as the project total.
 - `qase_project_context` requested users with no `limit` at all, so the API's own (smaller) default applied. It now asks for a full page like every other collection.
 - **`qql_search` no longer advertises an invalid QQL query.** The `recentFailures` example filtered failed results with `created >= now("-7d")`, but the `result` entity has no `created` field — the only timestamp it exposes is `ended`. The broken query was surfaced both in the `qql_search` tool description and in `qql_help` output, so models were being taught the error at the schema level. It now reads `ended >= now("-7d")`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.4]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`qase_project_context` no longer truncates collections silently.** Suites, milestones, environments, custom fields, and users were each capped at the first 100 entities with no indication in the response — a project with 2 711 suites reported "Suites: 100" and the consumer had no way to learn it was seeing 3.7% of the data. The result now carries a `coverage` field with `{ total, loaded, truncated }` per collection, and the summary spells out `100 of 2711 ⚠️ truncated` plus how to get the rest. The "Top-level suites (N of M total)" header no longer presents the loaded slice as the project total.
+- `qase_project_context` requested users with no `limit` at all, so the API's own (smaller) default applied. It now asks for a full page like every other collection.
 - **`qql_search` no longer advertises an invalid QQL query.** The `recentFailures` example filtered failed results with `created >= now("-7d")`, but the `result` entity has no `created` field — the only timestamp it exposes is `ended`. The broken query was surfaced both in the `qql_search` tool description and in `qql_help` output, so models were being taught the error at the schema level. It now reads `ended >= now("-7d")`.
 - `qql_help` claimed that "queries are case-sensitive for field values". Enum values in fact accept either the display label or its slug (`severity = "Blocker"` and `severity = "blocker"` match the same value); only `status` and `type` on the `requirement` entity are case-sensitive. The help text now says so, and additionally documents which date fields each entity exposes and that boolean fields accept both `is true` and `= true`.
 - `qql_help` omitted the `!~` operator and the `startOfWeek` / `endOfWeek` / `startOfMonth` / `endOfMonth` functions.
+
+### Added
+
+- **`qase_project_context` accepts `full: true`** to page through every collection instead of fetching only the first 100 of each. Full and partial responses are cached under separate keys, and pagination stops early if a page comes back empty rather than looping.
 
 ## [2.0.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.4]
+## [2.1.0]
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`qql_help` now documents aggregation.** QQL supports `SELECT (...)` with `COUNT`/`MIN`/`MAX`/`AVG`/`SUM`/`FIRST`/`LAST`, plus `GROUP BY` and `HAVING`, but the help never mentioned it — so a count that one query can answer was being computed by paging through rows. The parentheses after `SELECT` are mandatory (the query fails without them), which is not guessable, and two response quirks that quietly corrupt reports are now called out: aggregates return enums as numeric IDs (`result.status` 1 = Passed, 2 = Failed, 5 = Skipped, 8 = Invalid; `automation` 0/1/2), and grouping by a string field returns it with a `_title` suffix (`GROUP BY suite` → `suite_title`).
+- **`qql_help` now lists the fields of each entity**, replacing six label-only lines. Field names are not uniform across entities, which is the main source of failing queries, so the traps are stated explicitly: `case.suite` is a title but `result.suite` is a numeric ID; `result` has no run-ID field (`run` matches the run title, so results cannot be tied to a run ID in QQL); `result` has no `environment`; `requirement` has no link to cases; and `case.suiteTree` (a suite plus all descendants) is documented for the first time.
+- **`qql_help` gained an `enumValues` topic** covering the valid values per field, including two that fail when guessed: `priority` has no `"critical"` (that is a `severity`), and `run.status` is `In Progress`/`Passed`/`Failed`/`Aborted` — `"active"` is not a status. `result.status` has no `Untested`.
 - **`qase_project_context` accepts `full: true`** to page through every collection instead of fetching only the first 100 of each. Full and partial responses are cached under separate keys, and pagination stops early if a page comes back empty rather than looping.
+
+### Changed
+
+- `qql_search` accepts queries up to 2 000 characters, matching what the REST endpoint allows. The previous 1 000-character cap halved how many IDs fit in an `in (...)` clause — roughly 80 instead of 170 — doubling the round-trips needed for any set-based analysis.
 
 ## [2.0.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`qql_search` no longer advertises an invalid QQL query.** The `recentFailures` example filtered failed results with `created >= now("-7d")`, but the `result` entity has no `created` field — the only timestamp it exposes is `ended`. The broken query was surfaced both in the `qql_search` tool description and in `qql_help` output, so models were being taught the error at the schema level. It now reads `ended >= now("-7d")`.
+- `qql_help` claimed that "queries are case-sensitive for field values". Enum values in fact accept either the display label or its slug (`severity = "Blocker"` and `severity = "blocker"` match the same value); only `status` and `type` on the `requirement` entity are case-sensitive. The help text now says so, and additionally documents which date fields each entity exposes and that boolean fields accept both `is true` and `= true`.
+- `qql_help` omitted the `!~` operator and the `startOfWeek` / `endOfWeek` / `startOfMonth` / `endOfMonth` functions.
+
 ## [2.0.3]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`qase_triage_defect` no longer accepts `run_id` or `failed_result_ids`.** Both were read from the arguments and then ignored — the tool only ever created the defect. `POST /v1/defect/{code}` accepts `title`, `actual_result`, `severity`, `milestone_id`, `attachments`, `custom_field`, and `tags`; there is no field for runs or results, and no endpoint to attach them afterwards. The `runs`/`results` arrays visible on a defect are populated by the test runner when a result is reported as a defect. Reference failing results in `actual_result` instead.
 - **`qase_triage_defect` now requires `actual_result` and `severity`**, which the API has always required. Marking them optional produced requests the API rejects, with nothing in the tool contract to warn about it.
+- **`qql_help` now requires `topic`** and returns that one section. Previously omitting `topic` returned every section at once, which sends the whole reference into the context on each call — and the reference grew substantially in this release. `overview` is now a topic of its own, so the old default is still reachable as `topic: "overview"`. An omitted or unknown topic returns an error listing the valid ones.
 
 ### Fixed
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,4 +1,42 @@
-# Migration Guide: v1 → v2
+# Migration Guide
+
+Two migrations are covered here: the v1 → v2 tool rename (the bulk of this document), and the smaller [2.0.x → 2.1.0](#20x--210) change to `qase_triage_defect`.
+
+---
+
+## 2.0.x → 2.1.0
+
+### `qase_triage_defect` dropped `run_id` and `failed_result_ids`
+
+Both arguments were accepted and then ignored — the tool only ever created the defect. It also reported `Linked results: N` in its summary and `linked_results: N` in its structured output, both computed from the length of the ignored `failed_result_ids` array, so it claimed linking work it had not performed.
+
+This cannot be fixed by forwarding the arguments: `POST /v1/defect/{code}` accepts only `title`, `actual_result`, `severity`, `milestone_id`, `attachments`, `custom_field`, and `tags`, and the defects API has no endpoint for attaching runs or results afterwards. The `runs`/`results` arrays you see on a defect are populated by the test runner when a result is reported as a defect.
+
+**If you passed either argument**, remove it and put the context in `actual_result` instead:
+
+```diff
+ qase_triage_defect {
+   code: "PROJ",
+   title: "Checkout fails on empty cart",
+   severity: "blocker",
+-  actual_result: "HTTP 500",
+-  run_id: 7,
+-  failed_result_ids: ["a1b2c3", "d4e5f6"]
++  actual_result: "HTTP 500 — failing results a1b2c3, d4e5f6 in run #7"
+ }
+```
+
+**If you read `linked_results`** from the response, drop it — it was never a real count. The response is now `{ defect_id, defect }`.
+
+To associate results with a defect for real, report the result as a defect from the test runner (`is_defect` on the result), or link the defect to an external tracker issue with `qase_external_issue_link`.
+
+### `qase_triage_defect` now requires `actual_result` and `severity`
+
+The API has always required both. They were optional in the tool schema, which meant the tool advertised calls the API rejects. Any call that already succeeded is unaffected.
+
+---
+
+## Migration Guide: v1 → v2
 
 > **Breaking change**: v2 replaces all 83 v1 tool names with a consolidated set of 29 task-oriented tools (30 total, including the `qase_discover_tools` discovery tool).
 > Every tool name has changed. Update your prompts, workflows, and any automation that references tool names.
@@ -14,6 +52,8 @@
 | Metadata bootstrap | 6 separate list calls | `qase_project_context` (single call, cached) |
 | CI reporting | 3–4 manual steps | `qase_ci_report` composite |
 | Response format | Pretty-printed JSON, nulls included | Compact JSON (no indent), nulls stripped |
+
+> **Replacing a `list_*` tool with `qase_project_context`?** Each collection in the context response holds only its first 100 entities by default, where the v1 `list_*` tools let you page explicitly. Check the `coverage` field — it reports `{ total, loaded, truncated }` per collection — and pass `full: true` when you need the complete set. On a project with more than 100 suites, milestones, environments, custom fields, or users, treating the default response as complete gives you a partial answer. (Before 2.1.0 the truncation was not reported at all.)
 
 ---
 
@@ -237,9 +277,11 @@ Accepts a project code, run title, and an array of test results. Creates the run
 
 ### `qase_triage_defect`
 
-Streamlines the defect triage workflow. Creates a defect from a test failure description and optionally links it to failed result hashes from a run.
+Creates a defect from a test failure description. Requires `title`, `actual_result`, and `severity`.
 
-Replaces: `create_defect` (then manual linking).
+Note: the tool does **not** link the defect to runs or results — the API has no field or endpoint for that (see [2.0.x → 2.1.0](#20x--210) above). Reference the failing results in `actual_result`.
+
+Replaces: `create_defect`.
 
 ### `qase_regression_run`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qase/mcp-server",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qase/mcp-server",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qase/mcp-server",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qase/mcp-server",
-      "version": "2.0.4",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qase/mcp-server",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "mcpName": "io.qase/mcp-server",
   "description": "Official MCP server for Qase Test Management Platform",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qase/mcp-server",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "mcpName": "io.qase/mcp-server",
   "description": "Official MCP server for Qase Test Management Platform",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/qase-tms/qase-mcp-server",
     "source": "github"
   },
-  "version": "2.0.4",
+  "version": "2.1.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@qase/mcp-server",
-      "version": "2.0.4",
+      "version": "2.1.0",
       "transport": {
         "type": "stdio"
       },

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/qase-tms/qase-mcp-server",
     "source": "github"
   },
-  "version": "2.0.3",
+  "version": "2.0.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@qase/mcp-server",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "transport": {
         "type": "stdio"
       },

--- a/src/operations-v2/composites/triage-defect.test.ts
+++ b/src/operations-v2/composites/triage-defect.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for qase_triage_defect.
+ *
+ * The tool used to accept run_id and failed_result_ids, drop them on the floor,
+ * and then report "Linked results: N" as if the linking had happened. The API
+ * offers no way to attach runs or results to a defect at all.
+ */
+
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { setTestEnv } from '../../utils/test-helpers.js';
+
+setTestEnv();
+
+const mockCreateDefect = jest.fn();
+
+jest.mock('../../client/index.js', () => ({
+  getApiClient: () => ({
+    defects: { createDefect: mockCreateDefect },
+  }),
+}));
+
+import './triage-defect.js';
+import { toolRegistry } from '../../utils/registry.js';
+
+function invoke(args: Record<string, unknown>) {
+  const handler = toolRegistry.getHandler('qase_triage_defect')!;
+  return handler(args);
+}
+
+const validArgs = {
+  code: 'DEMO',
+  title: 'Checkout fails on empty cart',
+  actual_result: 'HTTP 500',
+  severity: 'blocker',
+};
+
+function summaryText(result: any): string {
+  return result.content.map((b: any) => b.text).join('\n');
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCreateDefect.mockReturnValue(
+    Promise.resolve({ data: { status: true, result: { id: 42 } } }),
+  );
+});
+
+describe('qase_triage_defect — no phantom linking', () => {
+  it('does not claim to have linked results', async () => {
+    const result = await invoke(validArgs);
+
+    expect(summaryText(result)).not.toContain('Linked results');
+    expect(result.structuredContent).not.toHaveProperty('linked_results');
+  });
+
+  it('reports the created defect', async () => {
+    const result = await invoke(validArgs);
+
+    expect(result.structuredContent.defect_id).toBe(42);
+    expect(summaryText(result)).toContain('Defect ID:** 42');
+  });
+
+  it('rejects run_id and failed_result_ids rather than silently ignoring them', () => {
+    const schema = toolRegistry.getTool('qase_triage_defect')!.inputSchema as any;
+
+    // The API has no field for either, so the tool must not advertise them.
+    expect(Object.keys(schema.properties)).not.toContain('run_id');
+    expect(Object.keys(schema.properties)).not.toContain('failed_result_ids');
+  });
+
+  it('does not promise linking in its description', () => {
+    const description = toolRegistry.getTool('qase_triage_defect')!.description!;
+
+    expect(description).toContain('no way to attach');
+  });
+});
+
+describe('qase_triage_defect — API-required fields', () => {
+  it('requires title, actual_result, and severity', () => {
+    const schema = toolRegistry.getTool('qase_triage_defect')!.inputSchema as any;
+
+    // POST /v1/defect/{code} requires all three; marking them optional only
+    // produced requests the API rejects.
+    expect(schema.required).toContain('title');
+    expect(schema.required).toContain('actual_result');
+    expect(schema.required).toContain('severity');
+  });
+
+  it('forwards the defect payload to the API', async () => {
+    await invoke({ ...validArgs, tags: ['checkout'] });
+
+    expect(mockCreateDefect).toHaveBeenCalledWith('DEMO', {
+      title: validArgs.title,
+      actual_result: validArgs.actual_result,
+      severity: 'blocker',
+      tags: ['checkout'],
+    });
+  });
+});

--- a/src/operations-v2/composites/triage-defect.ts
+++ b/src/operations-v2/composites/triage-defect.ts
@@ -2,23 +2,20 @@ import { z } from 'zod';
 import { getApiClient } from '../../client/index.js';
 import { toolRegistry, CreateAnnotation } from '../../utils/registry.js';
 import { toResultAsync, createToolError } from '../../utils/errors.js';
-import { ProjectCodeSchema, IdSchema } from '../../utils/validation.js';
+import { ProjectCodeSchema } from '../../utils/validation.js';
 import { TriageDefectOutput } from '../../utils/output-schemas.js';
 import { richResult, summaryBlock, dataBlock } from '../../utils/rich-response.js';
 
 const Schema = z.object({
   code: ProjectCodeSchema,
   title: z.string().min(1).max(255).describe('Defect title'),
+  // title, actual_result, and severity are all required by POST /v1/defect/{code} —
+  // marking them optional here only produced requests the API rejects.
   severity: z
     .enum(['undefined', 'blocker', 'critical', 'major', 'normal', 'minor', 'trivial'])
-    .optional(),
-  actual_result: z.string().optional().describe('Observed behavior'),
+    .describe('Required by the API'),
+  actual_result: z.string().describe('Observed behavior. Required by the API'),
   description: z.string().optional(),
-  run_id: IdSchema.optional().describe('Run containing the failed results'),
-  failed_result_ids: z
-    .array(z.string())
-    .optional()
-    .describe('Result hashes to link to this defect (from the run)'),
   tags: z.array(z.string()).optional(),
   attachments: z.array(z.string()).optional(),
   custom_field: z.record(z.any()).optional(),
@@ -26,7 +23,7 @@ const Schema = z.object({
 
 async function handler(args: z.infer<typeof Schema>) {
   const client = getApiClient();
-  const { code, run_id: _run_id, failed_result_ids, ...defectData } = args;
+  const { code, ...defectData } = args;
 
   // Create defect
   const defectRes = await toResultAsync(client.defects.createDefect(code, defectData as any));
@@ -39,7 +36,6 @@ async function handler(args: z.infer<typeof Schema>) {
 
   const defectId = (defect as any).id;
 
-  const linkedCount = failed_result_ids?.length ?? 0;
   const severityIcon: Record<string, string> = {
     blocker: '🔴',
     critical: '🟠',
@@ -55,15 +51,14 @@ async function handler(args: z.infer<typeof Schema>) {
     '',
     `- **Defect ID:** ${defectId}`,
     `- **Project:** ${code}`,
-    `- **Severity:** ${args.severity || 'undefined'}`,
-    `- **Linked results:** ${linkedCount}`,
+    `- **Severity:** ${args.severity}`,
   ];
 
   if (args.actual_result) {
     lines.push('', '**Actual result:**', `> ${args.actual_result}`);
   }
 
-  const structured = { defect_id: defectId, defect, linked_results: linkedCount };
+  const structured = { defect_id: defectId, defect };
 
   return richResult([summaryBlock(lines.join('\n')), dataBlock(structured)], structured);
 }
@@ -71,8 +66,10 @@ async function handler(args: z.infer<typeof Schema>) {
 toolRegistry.register({
   name: 'qase_triage_defect',
   description:
-    'Create a defect from a test failure and optionally link it to failed results. ' +
-    'Streamlines the triage workflow: create defect → link to failing tests.',
+    'Create a defect from a test failure. Requires title, actual_result, and severity. ' +
+    'Note: the API offers no way to attach existing runs or results to a defect — the ' +
+    'runs/results seen on a defect are populated by the test runner when a result is ' +
+    'reported as a defect. Reference failing results in actual_result instead.',
   schema: Schema,
   handler,
   annotations: CreateAnnotation,

--- a/src/operations-v2/qql/index.ts
+++ b/src/operations-v2/qql/index.ts
@@ -24,7 +24,9 @@ const QqlSearchSchema = z.object({
   query: z
     .string()
     .min(1)
-    .max(1000)
+    // The REST endpoint accepts 2000 characters; capping at 1000 halved how many
+    // IDs fit in an `in (...)` clause and doubled the round-trips for set analysis.
+    .max(2000)
     .describe(
       'QQL query expression. Examples:\n' +
         '- entity = "case" and project = "DEMO" and status = "Actual"\n' +
@@ -53,9 +55,13 @@ const QqlSearchSchema = z.object({
  */
 const GetQqlHelpSchema = z.object({
   topic: z
-    .enum(['syntax', 'entities', 'operators', 'functions', 'examples'])
+    .enum(['syntax', 'entities', 'operators', 'functions', 'examples', 'aggregation', 'enumValues'])
     .optional()
-    .describe('Specific help topic, or omit for general overview'),
+    .describe(
+      'Specific help topic, or omit for general overview. Use "entities" for the per-entity ' +
+        'field lists (field names are NOT uniform across entities), "aggregation" for ' +
+        'SELECT/COUNT/GROUP BY, and "enumValues" for valid enum values.',
+    ),
 });
 
 // ============================================================================
@@ -118,9 +124,18 @@ async function getQqlHelp(args: z.infer<typeof GetQqlHelpSchema>) {
   const help = {
     overview: {
       description: 'QQL (Qase Query Language) allows powerful searches across Qase entities',
-      structure: 'entity = "TYPE" and CONDITION [and CONDITION...] [ORDER BY field ASC/DESC]',
+      structure:
+        'entity = "TYPE" and CONDITION [and CONDITION...] [SELECT (AGGREGATE...)] ' +
+        '[GROUP BY field] [HAVING condition] [ORDER BY field ASC/DESC]',
       entities: ['case', 'defect', 'run', 'result', 'plan', 'requirement'],
       note: 'QQL is only available in Business and Enterprise Qase subscriptions',
+      fieldNamesVary:
+        'Field names are NOT uniform across entities — see the `entities` topic before writing ' +
+        'a query. Most common failure: `created` exists on case/defect/plan/requirement but ' +
+        'NOT on run (started/ended) or result (ended only).',
+      countWithoutPaging:
+        'To count or aggregate, use SELECT (COUNT(id)) rather than paging through rows — ' +
+        'see the `aggregation` topic.',
     },
     syntax: {
       basicStructure: 'entity = "TYPE" and CONDITION [and CONDITION...]',
@@ -137,12 +152,60 @@ async function getQqlHelp(args: z.infer<typeof GetQqlHelpSchema>) {
         '(no created/updated); run has started/ended',
     },
     entities: {
-      case: 'Test cases - entity = "case"',
-      defect: 'Defects/bugs - entity = "defect"',
-      run: 'Test runs - entity = "run"',
-      result: 'Test results - entity = "result"',
-      plan: 'Test plans - entity = "plan"',
-      requirement: 'Requirements - entity = "requirement"',
+      case:
+        'Test cases — entity = "case". Fields: id, title, description, preconditions, ' +
+        'postconditions, status, type, behavior, automation, isManual, isToBeAutomated, ' +
+        'priority, severity, layer, isMuted, isFlaky, isAiGenerated, suite, suiteTree, ' +
+        'milestone, tags, project, author, createdBy, updatedBy, created, updated, deleted, ' +
+        'isDeleted, plus custom fields via cf["Name"]. Note: `suite` matches the suite TITLE ' +
+        '(a string), and `suiteTree` matches a suite plus all of its descendants.',
+      defect:
+        'Defects/bugs — entity = "defect". Fields: id, title, actual_result, status, severity, ' +
+        'resolved, isResolved, milestone, tags, project, author, createdBy, created, updated, ' +
+        'deleted, isDeleted, assignee, plus custom fields.',
+      run:
+        'Test runs — entity = "run". Fields: id, title, description, status, plan, environment, ' +
+        'milestone, started, ended, isStarted, isEnded, isPublic, isAutotest, isScheduledRun, ' +
+        'hash, type, tags, project, author, createdBy, deleted, isDeleted, plus custom fields. ' +
+        'Note: no created/updated — use started/ended. status values: "In Progress", "Passed", ' +
+        '"Failed", "Aborted" ("active" is not a status).',
+      result:
+        'Test results — entity = "result". Fields: id, caseId, case, run, status, priority, ' +
+        'severity, type, layer, suite, tags, comment, timeSpent, ended, isEnded, deleted, ' +
+        'isDeleted, milestone, project, author, createdBy, assignee. Note: no created/updated ' +
+        '(only `ended`), no title/description, no custom fields, and no environment. Unlike ' +
+        'case.suite, result.suite is a numeric suite ID. There is no run-ID field — `run` ' +
+        'matches the run TITLE, so results cannot be tied to a specific run ID in QQL; use ' +
+        'GET /v1/result/{code}?filters[run]=ID via qase_api for that. status has no ' +
+        '"Untested" value.',
+      plan: 'Test plans — entity = "plan". Fields: id, title, description, project, created, updated, deleted, isDeleted.',
+      requirement:
+        'Requirements — entity = "requirement". Fields: id, title, description, parent, status, ' +
+        'type, project, author, createdBy, created, updated, deleted, isDeleted. Note: no link ' +
+        'to cases, and status/type are the only case-SENSITIVE enum values in QQL ' +
+        '(type = "User story" matches, "user-story" does not).',
+    },
+    aggregation: {
+      description:
+        'QQL can aggregate server-side instead of making you page through rows and count them.',
+      functions: ['COUNT', 'MIN', 'MAX', 'AVG', 'SUM', 'FIRST', 'LAST'],
+      syntax:
+        'SELECT (aggregate[, aggregate...]) [GROUP BY field] [HAVING condition] — the ' +
+        'parentheses after SELECT are MANDATORY; without them the query fails with ' +
+        '"Query is invalid".',
+      examples: [
+        'entity = "result" and project = "DEMO" and status = "failed" SELECT (COUNT(id))',
+        'entity = "result" and project = "DEMO" SELECT (COUNT(id)) GROUP BY status',
+        'entity = "case" and project = "DEMO" SELECT (COUNT(id)) GROUP BY suite HAVING COUNT(id) > 10',
+        'entity = "result" and project = "DEMO" SELECT (AVG(timeSpent), MAX(timeSpent))',
+      ],
+      enumsComeBackAsNumbers:
+        'In aggregate results, enum fields are returned as their numeric IDs, not labels: ' +
+        'result.status 1 = Passed, 2 = Failed, 5 = Skipped, 8 = Invalid; ' +
+        'automation 0 = Manual, 1 = To be automated, 2 = Automated. Map them before reporting.',
+      groupByAddsTitleSuffix:
+        'Grouping by a string field returns it with a _title suffix — GROUP BY suite yields ' +
+        'a `suite_title` key in the response, not `suite`.',
     },
     operators: {
       comparison: ['=', '!=', '<', '<=', '>', '>='],
@@ -150,6 +213,17 @@ async function getQqlHelp(args: z.infer<typeof GetQqlHelpSchema>) {
       array: ['in', 'not in'],
       null: ['is empty', 'is not empty'],
       logical: ['and', 'or', 'not'],
+    },
+    enumValues: {
+      priority:
+        '"Not set", "High", "Medium", "Low" — there is NO "critical" priority; ' +
+        'priority = "critical" fails. Critical belongs to severity.',
+      severity: '"Not set", "Blocker", "Critical", "Major", "Normal", "Minor", "Trivial"',
+      caseStatus: '"Actual", "Draft", "Deprecated"',
+      caseAutomation: '"Manual" (a.k.a. "Not automated"), "To be automated", "Automated"',
+      defectStatus: '"Open", "In progress", "Resolved", "Invalid"',
+      runStatus: '"In Progress", "Passed", "Failed", "Aborted"',
+      resultStatus: '"passed", "failed", "skipped", "invalid" — there is no "Untested"',
     },
     functions: {
       currentUser: 'currentUser() - Returns current user ID',

--- a/src/operations-v2/qql/index.ts
+++ b/src/operations-v2/qql/index.ts
@@ -29,7 +29,7 @@ const QqlSearchSchema = z.object({
       'QQL query expression. Examples:\n' +
         '- entity = "case" and project = "DEMO" and status = "Actual"\n' +
         '- entity = "defect" and severity = "blocker" and status = "open"\n' +
-        '- entity = "result" and status = "failed" and created >= now("-7d")\n' +
+        '- entity = "result" and status = "failed" and ended >= now("-7d")\n' +
         '- entity = "run" and milestone ~ "Sprint 12"\n' +
         'See QQL documentation for full syntax and examples.',
     ),
@@ -126,8 +126,15 @@ async function getQqlHelp(args: z.infer<typeof GetQqlHelpSchema>) {
       basicStructure: 'entity = "TYPE" and CONDITION [and CONDITION...]',
       ordering: 'ORDER BY field ASC/DESC',
       customFields: 'cf["Field Name"] = value',
-      caseNotes: 'Queries are case-sensitive for field values',
+      caseNotes:
+        'Enum values accept either the display label or its slug — severity = "Blocker" and ' +
+        'severity = "blocker" match the same value. Exception: on the requirement entity, ' +
+        'status and type ARE case-sensitive (type = "User story", not "user-story").',
       stringMatching: '~ operator is case-insensitive substring match',
+      booleanFields: 'Boolean fields accept `is true` / `is false` as well as `= true` / `= false`',
+      dateFields:
+        'case, defect, plan, and requirement have created/updated; result has only `ended` ' +
+        '(no created/updated); run has started/ended',
     },
     entities: {
       case: 'Test cases - entity = "case"',
@@ -139,7 +146,7 @@ async function getQqlHelp(args: z.infer<typeof GetQqlHelpSchema>) {
     },
     operators: {
       comparison: ['=', '!=', '<', '<=', '>', '>='],
-      string: ['~', 'is', 'is not'],
+      string: ['~', '!~', 'is', 'is not'],
       array: ['in', 'not in'],
       null: ['is empty', 'is not empty'],
       logical: ['and', 'or', 'not'],
@@ -147,9 +154,14 @@ async function getQqlHelp(args: z.infer<typeof GetQqlHelpSchema>) {
     functions: {
       currentUser: 'currentUser() - Returns current user ID',
       activeUsers: 'activeUsers() - Returns all active user IDs',
-      now: 'now("+/-Nd/w/m") - Current timestamp with optional offset (d=days, w=weeks, m=months)',
-      startOfDay: 'startOfDay("YYYY-MM-DD") - Start of specified day',
-      endOfDay: 'endOfDay("YYYY-MM-DD") - End of specified day',
+      now: 'now("+/-Nd/w/m") - Current timestamp with optional offset (d=days, w=weeks, m=months; hours and years are NOT supported)',
+      startOfDay: 'startOfDay("YYYY-MM-DD") - Start of specified day (also accepts an offset)',
+      endOfDay: 'endOfDay("YYYY-MM-DD") - End of specified day (also accepts an offset)',
+      startOfWeek: 'startOfWeek("YYYY-MM-DD") - Start of specified week (also accepts an offset)',
+      endOfWeek: 'endOfWeek("YYYY-MM-DD") - End of specified week (also accepts an offset)',
+      startOfMonth:
+        'startOfMonth("YYYY-MM-DD") - Start of specified month (also accepts an offset)',
+      endOfMonth: 'endOfMonth("YYYY-MM-DD") - End of specified month (also accepts an offset)',
     },
     examples: QqlExamples,
   };

--- a/src/operations-v2/qql/index.ts
+++ b/src/operations-v2/qql/index.ts
@@ -8,7 +8,7 @@
 import { z } from 'zod';
 import { getApiClient } from '../../client/index.js';
 import { toolRegistry, ReadAnnotation } from '../../utils/registry.js';
-import { toResultAsync, createToolError } from '../../utils/errors.js';
+import { toResultAsync, createToolError, ToolExecutionError } from '../../utils/errors.js';
 import { QqlExamples } from '../../utils/qql-helpers.js';
 import { QqlSearchOutput } from '../../utils/output-schemas.js';
 import { richResult, summaryBlock, dataBlock, markdownTable } from '../../utils/rich-response.js';
@@ -51,16 +51,39 @@ const QqlSearchSchema = z.object({
 });
 
 /**
+ * Help topics. `topic` is required: returning every section at once sends the
+ * whole reference into the context on each call, and the sections are large
+ * enough that it is worth asking for only the one needed.
+ */
+const HELP_TOPICS = [
+  'overview',
+  'syntax',
+  'entities',
+  'operators',
+  'functions',
+  'examples',
+  'aggregation',
+  'enumValues',
+] as const;
+
+/**
  * Schema for QQL help
  */
 const GetQqlHelpSchema = z.object({
   topic: z
-    .enum(['syntax', 'entities', 'operators', 'functions', 'examples', 'aggregation', 'enumValues'])
-    .optional()
+    .enum(HELP_TOPICS)
     .describe(
-      'Specific help topic, or omit for general overview. Use "entities" for the per-entity ' +
-        'field lists (field names are NOT uniform across entities), "aggregation" for ' +
-        'SELECT/COUNT/GROUP BY, and "enumValues" for valid enum values.',
+      'Which section to return (required — one section per call):\n' +
+        '- overview: what QQL is, overall query structure, subscription requirement\n' +
+        '- syntax: structure, ordering, custom fields, case-sensitivity, boolean and date fields\n' +
+        '- entities: the fields available on each entity — field names are NOT uniform across ' +
+        'entities, so read this before writing a query against an unfamiliar one\n' +
+        '- operators: comparison, matching, set, null, and logical operators\n' +
+        '- functions: currentUser, activeUsers, and the now/startOf*/endOf* date functions\n' +
+        '- examples: ready-made queries for common questions\n' +
+        '- aggregation: SELECT (COUNT/MIN/MAX/AVG/SUM/FIRST/LAST), GROUP BY, HAVING — use this ' +
+        'to count or summarise instead of paging through rows\n' +
+        '- enumValues: the valid values for priority, severity, and the per-entity status fields',
     ),
 });
 
@@ -240,11 +263,17 @@ async function getQqlHelp(args: z.infer<typeof GetQqlHelpSchema>) {
     examples: QqlExamples,
   };
 
-  if (topic) {
-    return { topic, content: help[topic as keyof typeof help] };
+  // Handlers receive raw MCP arguments, so the schema's `required` is not
+  // enforced at runtime — reject a missing or unknown topic with the list of
+  // valid ones rather than returning undefined content.
+  if (!topic || !(topic in help)) {
+    throw new ToolExecutionError(
+      `Unknown help topic${topic ? ` "${topic}"` : ''}. ` +
+        `Pass one of: ${HELP_TOPICS.join(', ')}.`,
+    );
   }
 
-  return help;
+  return { topic, content: help[topic] };
 }
 
 // ============================================================================
@@ -263,7 +292,11 @@ toolRegistry.register({
 
 toolRegistry.register({
   name: 'qql_help',
-  description: 'Get help and examples for Qase Query Language (QQL) syntax',
+  description:
+    'Get one section of the Qase Query Language (QQL) reference. `topic` is required — ask for ' +
+    'the section you need rather than the whole reference. Start with "entities" when you are ' +
+    'unsure which fields an entity has (they differ per entity), "aggregation" to count or ' +
+    'summarise without paging, and "enumValues" for valid field values.',
   schema: GetQqlHelpSchema,
   handler: getQqlHelp,
   annotations: ReadAnnotation,

--- a/src/operations-v2/qql/qql-help.test.ts
+++ b/src/operations-v2/qql/qql-help.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Tests for qql_help — the model's only guide to QQL, so wrong or missing
+ * information here turns directly into failing queries.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { setTestEnv } from '../../utils/test-helpers.js';
+
+setTestEnv();
+
+jest.mock('../../client/index.js', () => ({
+  getApiClient: () => ({ search: { search: jest.fn() } }),
+}));
+
+import './index.js';
+import { toolRegistry } from '../../utils/registry.js';
+
+function help(topic?: string): any {
+  const handler = toolRegistry.getHandler('qql_help')!;
+  return handler(topic ? { topic } : {});
+}
+
+/**
+ * Flatten a help section to text so assertions don't depend on its shape.
+ * Quotes are un-escaped so assertions can be written the way the help reads.
+ */
+function textOf(value: unknown): string {
+  return JSON.stringify(value).replace(/\\"/g, '"');
+}
+
+describe('qql_help — aggregation', () => {
+  it('documents aggregation instead of leaving the model to page and count', async () => {
+    const { content } = await help('aggregation');
+    const text = textOf(content);
+
+    for (const fn of ['COUNT', 'MIN', 'MAX', 'AVG', 'SUM', 'FIRST', 'LAST']) {
+      expect(text).toContain(fn);
+    }
+    expect(text).toContain('GROUP BY');
+    expect(text).toContain('HAVING');
+  });
+
+  it('warns that the parentheses after SELECT are mandatory', async () => {
+    const text = textOf((await help('aggregation')).content);
+
+    // Without them the query fails outright — not guessable.
+    expect(text).toContain('SELECT (');
+    expect(text.toLowerCase()).toContain('mandatory');
+  });
+
+  it('explains that aggregate enums come back as numbers', async () => {
+    const text = textOf((await help('aggregation')).content);
+
+    expect(text).toContain('2 = Failed');
+    expect(text).toContain('5 = Skipped');
+  });
+
+  it('explains the _title suffix added by GROUP BY', async () => {
+    const text = textOf((await help('aggregation')).content);
+
+    expect(text).toContain('suite_title');
+  });
+});
+
+describe('qql_help — per-entity fields', () => {
+  it('lists field names per entity rather than just labels', async () => {
+    const text = textOf((await help('entities')).content);
+
+    expect(text).toContain('suiteTree');
+    expect(text).toContain('timeSpent');
+    expect(text).toContain('isScheduledRun');
+  });
+
+  it('states which entities lack created/updated', async () => {
+    const text = textOf((await help('entities')).content);
+
+    // The single biggest source of failing queries.
+    expect(text).toContain('no created/updated');
+  });
+
+  it('warns that result has no run-ID field', async () => {
+    const text = textOf((await help('entities')).content);
+
+    expect(text).toContain('no run-ID field');
+  });
+
+  it('flags that case.suite is a title but result.suite is a numeric ID', async () => {
+    const text = textOf((await help('entities')).content);
+
+    expect(text).toContain('suite TITLE');
+    expect(text).toContain('numeric suite ID');
+  });
+
+  it('names requirement status/type as the case-sensitive exception', async () => {
+    const text = textOf((await help('entities')).content);
+
+    expect(text).toContain('User story');
+  });
+});
+
+describe('qql_help — enum values', () => {
+  it('warns that priority has no "critical" value', async () => {
+    const text = textOf((await help('enumValues')).content);
+
+    // priority = "critical" fails; critical is a severity.
+    expect(text).toContain('NO "critical" priority');
+  });
+
+  it('lists run statuses without the non-existent "active"', async () => {
+    const text = textOf((await help('enumValues')).content);
+
+    expect(text).toContain('In Progress');
+    expect(text).not.toContain('"active"');
+  });
+
+  it('states that result status has no Untested', async () => {
+    const text = textOf((await help('enumValues')).content);
+
+    expect(text).toContain('no "Untested"');
+  });
+});
+
+describe('qql_help — corrections to previous content', () => {
+  it('no longer claims field values are case-sensitive across the board', async () => {
+    const text = textOf((await help('syntax')).content);
+
+    expect(text).not.toContain('Queries are case-sensitive for field values');
+    expect(text).toContain('label or its slug');
+  });
+
+  it('documents the full set of date functions', async () => {
+    const text = textOf((await help('functions')).content);
+
+    for (const fn of ['startOfWeek', 'endOfWeek', 'startOfMonth', 'endOfMonth']) {
+      expect(text).toContain(fn);
+    }
+  });
+
+  it('includes the !~ operator', async () => {
+    const text = textOf((await help('operators')).content);
+
+    expect(text).toContain('!~');
+  });
+
+  it('offers the new topics through the schema enum', () => {
+    const schema = toolRegistry.getTool('qql_help')!.inputSchema as any;
+
+    expect(schema.properties.topic.enum).toContain('aggregation');
+    expect(schema.properties.topic.enum).toContain('enumValues');
+  });
+});
+
+describe('qql_search — query length', () => {
+  it('allows the 2000 characters the REST endpoint accepts', () => {
+    const schema = toolRegistry.getTool('qql_search')!.inputSchema as any;
+
+    // A 1000-char cap halved how many IDs fit in an `in (...)` clause.
+    expect(schema.properties.query.maxLength).toBe(2000);
+  });
+
+  it('advertises a valid recent-failures example', () => {
+    const schema = toolRegistry.getTool('qql_search')!.inputSchema as any;
+    const description: string = schema.properties.query.description;
+
+    expect(description).toContain('ended >= now("-7d")');
+    expect(description).not.toContain('created >= now');
+  });
+});

--- a/src/operations-v2/qql/qql-help.test.ts
+++ b/src/operations-v2/qql/qql-help.test.ts
@@ -150,6 +150,41 @@ describe('qql_help — corrections to previous content', () => {
   });
 });
 
+describe('qql_help — topic is required', () => {
+  it('declares topic as required in the schema', () => {
+    const schema = toolRegistry.getTool('qql_help')!.inputSchema as any;
+
+    // Returning every section at once put the whole reference into context on
+    // each call.
+    expect(schema.required).toContain('topic');
+  });
+
+  it('serves the overview as a topic of its own', async () => {
+    const { topic, content } = await help('overview');
+
+    expect(topic).toBe('overview');
+    expect(textOf(content)).toContain('Qase Query Language');
+  });
+
+  it('rejects a missing topic with the list of valid ones', async () => {
+    // Handlers get raw MCP arguments, so `required` is not enforced at runtime.
+    await expect(help()).rejects.toThrow(/Pass one of:.*aggregation/s);
+  });
+
+  it('rejects an unknown topic by name', async () => {
+    await expect(help('syntaxx')).rejects.toThrow(/Unknown help topic "syntaxx"/);
+  });
+
+  it('returns one section, not the whole reference', async () => {
+    const { content } = await help('operators');
+
+    // The operators section only — no sibling sections leaking in.
+    expect(content).toHaveProperty('comparison');
+    expect(content).not.toHaveProperty('entities');
+    expect(content).not.toHaveProperty('aggregation');
+  });
+});
+
 describe('qql_search — query length', () => {
   it('allows the 2000 characters the REST endpoint accepts', () => {
     const schema = toolRegistry.getTool('qql_search')!.inputSchema as any;

--- a/src/operations-v2/read/project-context.test.ts
+++ b/src/operations-v2/read/project-context.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Tests for qase_project_context — coverage reporting and full pagination.
+ *
+ * The tool fetches the first 100 entities of each collection by default. A
+ * project larger than that used to be truncated silently, leaving the consumer
+ * unable to tell a partial list from a complete one.
+ */
+
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { setTestEnv } from '../../utils/test-helpers.js';
+
+setTestEnv();
+
+const mockGetProject = jest.fn();
+const mockGetSuites = jest.fn();
+const mockGetMilestones = jest.fn();
+const mockGetEnvironments = jest.fn();
+const mockGetCustomFields = jest.fn();
+const mockGetUsers = jest.fn();
+
+jest.mock('../../client/index.js', () => ({
+  getApiClient: () => ({
+    projects: { getProject: mockGetProject },
+    suites: { getSuites: mockGetSuites },
+    milestones: { getMilestones: mockGetMilestones },
+    environment: { getEnvironments: mockGetEnvironments },
+    customFields: { getCustomFields: mockGetCustomFields },
+    users: { getUsers: mockGetUsers },
+  }),
+}));
+
+// In-memory cache stub — the real one would serve a stale entry across tests.
+const cacheStore = new Map<string, unknown>();
+jest.mock('../../cache/index.js', () => ({
+  getCache: async () => ({
+    get: async (k: string) => cacheStore.get(k),
+    set: async (k: string, v: unknown) => {
+      cacheStore.set(k, v);
+    },
+  }),
+  buildCacheKey: (parts: Record<string, string>) => JSON.stringify(parts),
+  hashToken: () => 'test-tenant',
+}));
+
+import './project-context.js';
+import { toolRegistry } from '../../utils/registry.js';
+
+/** A list response holding `count` synthetic entities out of `total`. */
+function listPage(total: number, count: number, offset = 0) {
+  const entities = Array.from({ length: count }, (_, i) => ({
+    id: offset + i + 1,
+    title: `Entity ${offset + i + 1}`,
+  }));
+  return Promise.resolve({ data: { status: true, result: { total, entities } } });
+}
+
+/** An endpoint serving `total` entities across pages of 100. */
+function paged(total: number) {
+  return (...args: unknown[]) => {
+    // Suites/milestones: (code, search, limit, offset). Users: (limit, offset).
+    const nums = args.filter((a): a is number => typeof a === 'number');
+    const [limit, offset] = [nums[0] ?? 100, nums[1] ?? 0];
+    return listPage(total, Math.max(0, Math.min(limit, total - offset)), offset);
+  };
+}
+
+function invoke(args: Record<string, unknown>) {
+  const handler = toolRegistry.getHandler('qase_project_context')!;
+  return handler(args);
+}
+
+/** The structured payload richResult carries alongside the summary blocks. */
+function structured(result: any) {
+  return result.structuredContent ?? result;
+}
+
+function summaryText(result: any): string {
+  return result.content.map((b: any) => b.text).join('\n');
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  cacheStore.clear();
+
+  mockGetProject.mockReturnValue(
+    Promise.resolve({ data: { status: true, result: { title: 'Dev Experience' } } }),
+  );
+  // Small collections that fit in a single page.
+  mockGetSuites.mockImplementation(paged(3));
+  mockGetMilestones.mockImplementation(paged(2));
+  mockGetEnvironments.mockImplementation(paged(1));
+  mockGetCustomFields.mockImplementation(paged(0));
+  mockGetUsers.mockImplementation(paged(4));
+});
+
+describe('qase_project_context — coverage reporting', () => {
+  it('reports every collection as complete when it fits in one page', async () => {
+    const result = structured(await invoke({ code: 'DEMO' }));
+
+    expect(result.coverage.suites).toEqual({ total: 3, loaded: 3, truncated: false });
+    expect(result.coverage.users).toEqual({ total: 4, loaded: 4, truncated: false });
+    expect(
+      Object.values(result.coverage).every((c: any) => c.truncated === false),
+    ).toBe(true);
+  });
+
+  it('flags truncation instead of silently dropping entities', async () => {
+    mockGetSuites.mockImplementation(paged(2711));
+
+    const result = await invoke({ code: 'DEVX' });
+
+    expect(structured(result).coverage.suites).toEqual({
+      total: 2711,
+      loaded: 100,
+      truncated: true,
+    });
+  });
+
+  it('states the truncation in the human-readable summary', async () => {
+    mockGetSuites.mockImplementation(paged(2711));
+
+    const summary = summaryText(await invoke({ code: 'DEVX' }));
+
+    // The real total must be visible, not just the 100 that were loaded.
+    expect(summary).toContain('100 of 2711');
+    expect(summary).toContain('truncated');
+    expect(summary).toContain('full: true');
+  });
+
+  it('does not describe loaded suites as the project total when truncated', async () => {
+    mockGetSuites.mockImplementation(paged(2711));
+
+    const summary = summaryText(await invoke({ code: 'DEVX' }));
+
+    // Regression guard: the header used to read "N of 100 total", presenting a
+    // 3.7% slice as the whole project.
+    expect(summary).not.toContain('of 100 total');
+    expect(summary).toContain('2711 in project');
+  });
+
+  it('falls back to the loaded count when the API omits total', async () => {
+    mockGetSuites.mockReturnValue(
+      Promise.resolve({ data: { status: true, result: { entities: [{ id: 1 }] } } }),
+    );
+
+    const result = structured(await invoke({ code: 'DEMO' }));
+
+    expect(result.coverage.suites).toEqual({ total: 1, loaded: 1, truncated: false });
+  });
+
+  it('reports a failed collection as empty without failing the whole call', async () => {
+    mockGetSuites.mockReturnValue(Promise.reject(new Error('boom')));
+
+    const result = structured(await invoke({ code: 'DEMO' }));
+
+    expect(result.coverage.suites).toEqual({ total: 0, loaded: 0, truncated: false });
+    // The rest of the context still arrives.
+    expect(result.coverage.users.loaded).toBe(4);
+  });
+});
+
+describe('qase_project_context — full pagination', () => {
+  it('fetches one page per collection by default', async () => {
+    mockGetSuites.mockImplementation(paged(2711));
+
+    await invoke({ code: 'DEVX' });
+
+    expect(mockGetSuites).toHaveBeenCalledTimes(1);
+    expect(mockGetSuites).toHaveBeenCalledWith('DEVX', undefined, 100, 0);
+  });
+
+  it('pages through everything when full is set', async () => {
+    mockGetSuites.mockImplementation(paged(250));
+
+    const result = structured(await invoke({ code: 'DEVX', full: true }));
+
+    expect(mockGetSuites).toHaveBeenCalledTimes(3); // 100 + 100 + 50
+    expect(result.coverage.suites).toEqual({ total: 250, loaded: 250, truncated: false });
+    expect(result.suites.entities).toHaveLength(250);
+  });
+
+  it('advances the offset on each page', async () => {
+    mockGetSuites.mockImplementation(paged(250));
+
+    await invoke({ code: 'DEVX', full: true });
+
+    const offsets = mockGetSuites.mock.calls.map((c) => c[3]);
+    expect(offsets).toEqual([0, 100, 200]);
+  });
+
+  it('stops instead of looping when a page comes back empty', async () => {
+    // Claims 5000 entities but serves nothing after the first page.
+    mockGetSuites.mockImplementation((...args: unknown[]) => {
+      const offset = args[3] as number;
+      return offset === 0 ? listPage(5000, 100) : listPage(5000, 0, offset);
+    });
+
+    const result = structured(await invoke({ code: 'DEVX', full: true }));
+
+    expect(mockGetSuites).toHaveBeenCalledTimes(2);
+    // The unmet total stays visible rather than being reported as complete.
+    expect(result.coverage.suites).toEqual({ total: 5000, loaded: 100, truncated: true });
+  });
+
+  it('caches full and partial responses separately', async () => {
+    mockGetSuites.mockImplementation(paged(250));
+
+    const partial = structured(await invoke({ code: 'DEVX' }));
+    expect(partial.coverage.suites.loaded).toBe(100);
+
+    // Must not be served the cached partial entry.
+    const complete = structured(await invoke({ code: 'DEVX', full: true }));
+    expect(complete.coverage.suites.loaded).toBe(250);
+  });
+
+  it('passes an explicit limit to getUsers, which previously had none', async () => {
+    await invoke({ code: 'DEMO' });
+
+    expect(mockGetUsers).toHaveBeenCalledWith(100, 0);
+  });
+});

--- a/src/operations-v2/read/project-context.ts
+++ b/src/operations-v2/read/project-context.ts
@@ -8,19 +8,88 @@ import { ProjectContextOutput } from '../../utils/output-schemas.js';
 import { getCache, buildCacheKey, hashToken } from '../../cache/index.js';
 import { getEffectiveToken } from '../../utils/auth-context.js';
 
+/** Entities requested per API call. 100 is the largest page the Qase API serves. */
+const PAGE_SIZE = 100;
+
+/**
+ * Hard cap on pages fetched per collection when `full` is set. A project with
+ * more entities than this still reports the true `total`, so the truncation
+ * stays visible instead of silently capping.
+ */
+const MAX_PAGES = 50;
+
 const Schema = z.object({
   code: ProjectCodeSchema,
+  full: z
+    .boolean()
+    .optional()
+    .describe(
+      'Page through every suite, milestone, environment, custom field, and user instead of ' +
+        `fetching only the first ${PAGE_SIZE} of each (default: false). Use this when a ` +
+        'collection is reported as truncated and you need the complete set — it costs one API ' +
+        'call per 100 entities and can return thousands of items, so prefer the targeted list ' +
+        'tools or qql_search when you only need a subset.',
+    ),
 });
 
+/** A Qase list endpoint response: `{ total, filtered, count, entities }`. */
+type ListPage = { total?: number; entities?: unknown[] } | null;
+
+/** Per-collection completeness metadata attached to the result. */
+interface Coverage {
+  /** Entities the project actually has, as reported by the API. */
+  total: number;
+  /** Entities included in this response. */
+  loaded: number;
+  /** True when `loaded < total` — the consumer is seeing a partial set. */
+  truncated: boolean;
+}
+
+function coverageOf(page: ListPage): Coverage {
+  const loaded = page?.entities?.length ?? 0;
+  // Fall back to `loaded` when the endpoint omits `total`, so we never claim a
+  // truncation we cannot substantiate.
+  const total = page?.total ?? loaded;
+  return { total, loaded, truncated: loaded < total };
+}
+
+/**
+ * Fetch the first page of a collection, then keep paging while the API reports
+ * more entities than collected. Returns the shape of a single list response with
+ * `entities` holding everything fetched.
+ */
+async function fetchAll(
+  fetchPage: (limit: number, offset: number) => Promise<ListPage>,
+): Promise<ListPage> {
+  const first = await fetchPage(PAGE_SIZE, 0);
+  if (!first) return null;
+
+  const entities = [...(first.entities ?? [])];
+  const total = first.total ?? entities.length;
+
+  for (let page = 1; entities.length < total && page < MAX_PAGES; page++) {
+    const next = await fetchPage(PAGE_SIZE, page * PAGE_SIZE);
+    const batch = next?.entities ?? [];
+    // No progress (empty page or an endpoint ignoring offset) — stop rather than
+    // spin until MAX_PAGES.
+    if (batch.length === 0) break;
+    entities.push(...batch);
+  }
+
+  return { ...first, entities };
+}
+
 async function handler(args: z.infer<typeof Schema>) {
-  const { code } = args;
+  const { code, full = false } = args;
   const cache = await getCache();
   const host = process.env.QASE_API_DOMAIN || 'api.qase.io';
   const key = buildCacheKey({
     host,
     tenantId: hashToken(getEffectiveToken()),
     resource: 'project_context',
-    scope: code,
+    // Keep full and partial responses in separate cache entries — otherwise a
+    // cached partial set would be served for full: true, and vice versa.
+    scope: full ? `${code}:full` : code,
   });
 
   const cached = await cache.get(key);
@@ -28,33 +97,71 @@ async function handler(args: z.infer<typeof Schema>) {
 
   const client = getApiClient();
 
-  const [projectRes, suitesRes, milestonesRes, envsRes, customFieldsRes, usersRes] =
-    await Promise.allSettled([
-      toResultAsync(client.projects.getProject(code)),
-      toResultAsync(client.suites.getSuites(code, undefined, 100, 0)),
-      toResultAsync(client.milestones.getMilestones(code, undefined, 100, 0)),
-      toResultAsync(client.environment.getEnvironments(code, undefined, undefined, 100, 0)),
-      toResultAsync(client.customFields.getCustomFields(undefined, undefined, 100, 0)),
-      toResultAsync(client.users.getUsers()),
-    ]);
-
+  /** Unwrap one settled API call; a rejected or errored call becomes null. */
   const extract = <T>(settled: PromiseSettledResult<any>): T | null => {
     if (settled.status === 'fulfilled') {
       return settled.value.match(
-        (r: any) => r.data.result,
+        (r: any) => r.data.result as T,
         () => null,
       );
     }
     return null;
   };
 
+  /**
+   * Fetch one page of a collection, returning null if the call fails so a single
+   * failing collection leaves the rest of the context intact.
+   */
+  const page =
+    (fetchPage: (limit: number, offset: number) => Promise<any>) =>
+    async (limit: number, offset: number): Promise<ListPage> => {
+      const settled = await Promise.allSettled([toResultAsync(fetchPage(limit, offset))]);
+      return extract<NonNullable<ListPage>>(settled[0]);
+    };
+
+  /** One page by default, every page when `full` is set. */
+  const collect = (
+    fetchPage: (limit: number, offset: number) => Promise<any>,
+  ): Promise<ListPage> => {
+    const fetch = page(fetchPage);
+    return full ? fetchAll(fetch) : fetch(PAGE_SIZE, 0);
+  };
+
+  const [projectSettled, suites, milestones, environments, customFields, users] = await Promise.all(
+    [
+      Promise.allSettled([toResultAsync(client.projects.getProject(code))]).then(([s]) => s),
+      collect((limit, offset) => client.suites.getSuites(code, undefined, limit, offset)),
+      collect((limit, offset) => client.milestones.getMilestones(code, undefined, limit, offset)),
+      collect((limit, offset) =>
+        client.environment.getEnvironments(code, undefined, undefined, limit, offset),
+      ),
+      collect((limit, offset) =>
+        client.customFields.getCustomFields(undefined, undefined, limit, offset),
+      ),
+      // Previously called with no limit at all, so the API's own (smaller)
+      // default silently applied.
+      collect((limit, offset) => client.users.getUsers(limit, offset)),
+    ] as const,
+  );
+
+  const coverage = {
+    suites: coverageOf(suites),
+    milestones: coverageOf(milestones),
+    environments: coverageOf(environments),
+    custom_fields: coverageOf(customFields),
+    users: coverageOf(users),
+  };
+
   const context = {
-    project: extract(projectRes),
-    suites: extract(suitesRes),
-    milestones: extract(milestonesRes),
-    environments: extract(envsRes),
-    custom_fields: extract(customFieldsRes),
-    users: extract(usersRes),
+    project: extract<Record<string, unknown>>(projectSettled),
+    suites,
+    milestones,
+    environments,
+    custom_fields: customFields,
+    users,
+    // Machine-readable completeness per collection, so a consumer can tell a
+    // partial set from a complete one without counting entities itself.
+    coverage,
   };
 
   const TTL = 5 * 60 * 1000; // 5 minutes
@@ -65,18 +172,34 @@ async function handler(args: z.infer<typeof Schema>) {
   const suitesList: any[] = (context.suites as any)?.entities ?? [];
   const milestonesList: any[] = (context.milestones as any)?.entities ?? [];
   const envsList: any[] = (context.environments as any)?.entities ?? [];
-  const customFieldsList: any[] = (context.custom_fields as any)?.entities ?? [];
-  const usersList: any[] = (context.users as any)?.entities ?? [];
+
+  /** "100 of 2711 ⚠️ truncated" when partial, plain "42" when complete. */
+  const countOf = (c: Coverage): string =>
+    c.truncated ? `${c.loaded} of ${c.total} ⚠️ truncated` : `${c.loaded}`;
 
   const lines = [
     `## Project: ${projectName} (${code})`,
     '',
-    `- **Suites:** ${suitesList.length}`,
-    `- **Milestones:** ${milestonesList.length}`,
-    `- **Environments:** ${envsList.length}`,
-    `- **Custom fields:** ${customFieldsList.length}`,
-    `- **Team members:** ${usersList.length}`,
+    `- **Suites:** ${countOf(coverage.suites)}`,
+    `- **Milestones:** ${countOf(coverage.milestones)}`,
+    `- **Environments:** ${countOf(coverage.environments)}`,
+    `- **Custom fields:** ${countOf(coverage.custom_fields)}`,
+    `- **Team members:** ${countOf(coverage.users)}`,
   ];
+
+  const truncated = Object.entries(coverage)
+    .filter(([, c]) => c.truncated)
+    .map(([name]) => name);
+
+  if (truncated.length > 0) {
+    lines.push(
+      '',
+      `⚠️ **Partial data:** ${truncated.join(', ')} exceed ${PAGE_SIZE} entities and are ` +
+        'truncated above. Do not treat the lists below as complete. Call ' +
+        `\`qase_project_context({ code: "${code}", full: true })\` for the full set, or use ` +
+        'the targeted list tools / `qql_search` to query a subset.',
+    );
+  }
 
   if (envsList.length > 0) {
     lines.push('', '**Environments:** ' + envsList.map((e: any) => e.title).join(', '));
@@ -93,7 +216,12 @@ async function handler(args: z.infer<typeof Schema>) {
 
   if (suitesList.length > 0) {
     const topLevel = suitesList.filter((s: any) => !s.parent_id);
-    lines.push('', `**Top-level suites** (${topLevel.length} of ${suitesList.length} total):`);
+    // Qualify the denominator as loaded, not total — with a truncated set the
+    // suites in hand are only a slice of the project.
+    const scope = coverage.suites.truncated
+      ? `${topLevel.length} of ${suitesList.length} loaded, ${coverage.suites.total} in project`
+      : `${topLevel.length} of ${suitesList.length} total`;
+    lines.push('', `**Top-level suites** (${scope}):`);
     for (const s of topLevel.slice(0, 10)) {
       lines.push(`- ${s.title}`);
     }
@@ -114,7 +242,10 @@ toolRegistry.register({
     'Get full project context in one call: project details, suites tree, milestones, ' +
     'environments, custom fields, and users. Cached for 5 minutes. Use this as the ' +
     'first call when starting work with a project — it seeds all the metadata the LLM ' +
-    'needs without making 6 separate list calls.',
+    `needs without making 6 separate list calls. Each collection returns its first ${PAGE_SIZE} ` +
+    'entities by default; the `coverage` field reports `{ total, loaded, truncated }` per ' +
+    'collection, so check it before assuming a list is complete. Pass `full: true` to page ' +
+    'through everything.',
   schema: Schema,
   handler,
   annotations: ReadAnnotation,

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -33,9 +33,8 @@ export const TriageDefectOutput: OutputSchema = {
   properties: {
     defect_id: { type: 'integer', description: 'Created defect ID' },
     defect: { type: 'object', description: 'Full defect entity' },
-    linked_results: { type: 'integer', description: 'Number of linked result hashes' },
   },
-  required: ['defect_id', 'linked_results'],
+  required: ['defect_id'],
 };
 
 export const QqlSearchOutput: OutputSchema = {

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -56,8 +56,15 @@ export const ProjectContextOutput: OutputSchema = {
     environments: { type: 'object', description: 'Environments list' },
     custom_fields: { type: 'object', description: 'Custom fields list' },
     users: { type: 'object', description: 'Team members list' },
+    coverage: {
+      type: 'object',
+      description:
+        'Per-collection completeness: each of suites, milestones, environments, custom_fields, ' +
+        'and users maps to { total, loaded, truncated }. When truncated is true the list holds ' +
+        'only the first `loaded` of `total` entities — re-call with full: true for the rest.',
+    },
   },
-  required: ['project', 'suites', 'milestones', 'environments'],
+  required: ['project', 'suites', 'milestones', 'environments', 'coverage'],
 };
 
 export const DeleteOutput: OutputSchema = {

--- a/src/utils/qql-helpers.test.ts
+++ b/src/utils/qql-helpers.test.ts
@@ -84,7 +84,9 @@ describe('QQL Helpers', () => {
       expect(query).toContain('entity = "result"');
       expect(query).toContain('project = "DEMO"');
       expect(query).toContain('status = "failed"');
-      expect(query).toContain('now("-7d")');
+      expect(query).toContain('ended >= now("-7d")');
+      // Results have no `created` field — filtering on it makes the query invalid
+      expect(query).not.toContain('created');
     });
 
     it('should generate blocker defects query', () => {

--- a/src/utils/qql-helpers.ts
+++ b/src/utils/qql-helpers.ts
@@ -75,9 +75,10 @@ export class QqlQueryBuilder {
  * Common QQL query examples
  */
 export const QqlExamples = {
-  // Find all failed test results in last 7 days
+  // Find all failed test results in last 7 days.
+  // Results have no `created` field — `ended` is the only timestamp to filter on.
   recentFailures: (projectCode: string) =>
-    `entity = "result" and project = "${projectCode}" and status = "failed" and created >= now("-7d")`,
+    `entity = "result" and project = "${projectCode}" and status = "failed" and ended >= now("-7d")`,
 
   // Find all open blocker defects
   blockerDefects: (projectCode: string) =>


### PR DESCRIPTION
## Summary
Six fixes, all cases where the tool schema or response told the consumer something untrue — so a model following the contract either made failing calls or reported work that never happened. Reported and verified against a live workspace (DEVX) and cross-checked with `qase-tms/specs/testops-api`.

### 1. `qase_triage_defect` reported linking it never did
`run_id` and `failed_result_ids` were destructured out of the arguments and never used — only the defect was created. The tool then printed `Linked results: N` and returned `linked_results: N` from the length of the ignored array.

This cannot be wired up: `POST /v1/defect/{code}` takes only `title`, `actual_result`, `severity`, `milestone_id`, `attachments`, `custom_field`, `tags`, and the defects API has no attach endpoint (`createDefect`, `updateDefect`, `deleteDefect`, `resolveDefect`, `updateDefectStatus`, `getDefect(s)` — that's all of it). The `runs`/`results` arrays on a defect are filled in by the runner. **Both arguments and the false report are removed.**

**1b.** `actual_result` and `severity` are now required, matching the API (`DefectCreate` has them non-optional). They were optional in the schema, so the tool advertised calls the API rejects.

### 2. Invalid QQL example hardcoded into the schema
`created >= now("-7d")` on `result` → `unavailable attribute: created`; the only timestamp is `ended`. It sat in `QqlExamples.recentFailures`, in the `qql_search` parameter description, and in `qql_help` output. Fixed. The other examples were re-checked and left alone.

### 3. `qase_project_context` truncated silently
Every collection capped at 100 with nothing in the response to say so — 2 711 suites reported as `Suites: 100`, and the `Top-level suites (N of M total)` header called the loaded slice the total. Now: a `coverage` field (`{ total, loaded, truncated }` per collection, required in the output schema), an explicit `100 of 2711 ⚠️ truncated` in the summary, and `full: true` to page through everything (separate cache key, stops on an empty page, 50-page cap with `truncated` staying `true` if hit). `users` were fetched with no `limit` at all, so the API's smaller default applied — now an explicit page.

### 4. `qql_help` never mentioned aggregation
`SELECT (...)` with `COUNT`/`MIN`/`MAX`/`AVG`/`SUM`/`FIRST`/`LAST`, `GROUP BY`, `HAVING` — all undocumented, so counts were computed by paging rows. Added, including that the parentheses are mandatory (fails without them), that aggregates return enums as numeric IDs (`result.status` 1/2/5/8, `automation` 0/1/2), and that `GROUP BY suite` returns `suite_title`.

### 5. `qql_help` had no per-entity fields, and one wrong claim
Six label-only lines replaced with real field lists plus the traps: `case.suite` is a title but `result.suite` is a numeric ID; `result` has no run-ID field (`run` matches the title, so results can't be tied to a run ID in QQL); no `environment` on `result`; no case link on `requirement`; `case.suiteTree` documented. New `enumValues` topic: `priority` has no `"critical"`, `run.status` has no `"active"`, `result.status` has no `Untested`. Corrected `'Queries are case-sensitive for field values'` — enum values accept label or slug; only `requirement.status`/`type` are case-sensitive. Added the missing `!~`, `startOfWeek`/`endOfWeek`/`startOfMonth`/`endOfMonth`.

### 6. `qql_help` now requires `topic`
Omitting it returned every section at once — the whole reference into context on each call, and the reference grew a lot in (4) and (5). `topic` is required and serves one section; `overview` became a topic of its own, so the old default is reachable as `topic: "overview"`. Since handlers get raw MCP arguments, a missing or unknown topic raises an error listing the valid ones rather than returning `undefined`.

### 7. `qql_search` capped queries at half the API limit
`.max(1000)` → `.max(2000)`, matching REST. The old cap fit ~80 IDs in an `in (...)` clause instead of ~170, doubling round-trips for set-based analysis.

### Version
2.1.0, not 2.0.4 — the `qase_triage_defect` changes are breaking. `docs/migration.md` gains a `2.0.x → 2.1.0` section with a diff for callers, and its stale claim that the tool "optionally links it to failed result hashes" is corrected. The guide also now warns that `qase_project_context`, which it recommends as the replacement for every v1 `list_*` tool, returns only the first 100 per collection without `full: true`.

## Test plan
- [x] `npm run build`
- [x] `npm test` — 463 tests, 1 pre-existing skip, all green (+36 new)
- [x] `npm run lint` — 0 errors, pre-existing `any` warnings only
- [x] New `triage-defect.test.ts`: no phantom `linked_results`, removed args absent from the schema, required fields, payload forwarded
- [x] New `qql-help.test.ts`: aggregation, mandatory parens, numeric enums, `_title` suffix, per-entity fields, enum traps, corrected case-sensitivity, 2000-char cap
- [x] `project-context.test.ts`: truncation reporting, the `of 100 total` regression, missing `total`, a failing collection not sinking the rest, offsets advancing, empty-page bailout, separate full/partial cache entries
- [x] QQL example test tightened — it asserted only `now("-7d")` and would have missed the wrong field
