### PR TITLE
fix: put SELECT first in qql_help aggregation examples (v2.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1]
+
+### Fixed
+
+- **The aggregation examples added in 2.1.0 were themselves invalid QQL.** They placed `SELECT (...)` after the conditions (`entity = "result" and ... SELECT (COUNT(id))`), which the API rejects with a bare `Query is invalid` that does not say what is wrong — so a model copying the form from `qql_help` had no way to recover. `SELECT (...)` must come first: `SELECT (COUNT(id)) entity = "result" and project = "DEMO" GROUP BY status`. All four examples, `overview.structure`, and `aggregation.syntax` are corrected, and the position requirement is now stated as explicitly as the mandatory parentheses already were. `overview.structure` also shows the filtering and aggregating forms separately instead of as one combined line, since the combined form is what suggested the wrong order.
+- A regression test now asserts that every query string in every `qql_help` topic which uses `SELECT (` starts with it — verified to fail against the 2.1.0 text.
+
 ## [2.1.0]
 
 ### Breaking Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qase/mcp-server",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qase/mcp-server",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qase/mcp-server",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "mcpName": "io.qase/mcp-server",
   "description": "Official MCP server for Qase Test Management Platform",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/qase-tms/qase-mcp-server",
     "source": "github"
   },
-  "version": "2.1.0",
+  "version": "2.1.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@qase/mcp-server",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/operations-v2/qql/index.ts
+++ b/src/operations-v2/qql/index.ts
@@ -148,8 +148,10 @@ async function getQqlHelp(args: z.infer<typeof GetQqlHelpSchema>) {
     overview: {
       description: 'QQL (Qase Query Language) allows powerful searches across Qase entities',
       structure:
-        'entity = "TYPE" and CONDITION [and CONDITION...] [SELECT (AGGREGATE...)] ' +
-        '[GROUP BY field] [HAVING condition] [ORDER BY field ASC/DESC]',
+        'Filtering: entity = "TYPE" and CONDITION [and CONDITION...] ' +
+        '[ORDER BY field ASC/DESC]. ' +
+        'Aggregating: SELECT (AGGREGATE[, ...]) entity = "TYPE" and CONDITION... ' +
+        '[GROUP BY field] [HAVING condition] — SELECT comes FIRST, before the conditions.',
       entities: ['case', 'defect', 'run', 'result', 'plan', 'requirement'],
       note: 'QQL is only available in Business and Enterprise Qase subscriptions',
       fieldNamesVary:
@@ -157,8 +159,9 @@ async function getQqlHelp(args: z.infer<typeof GetQqlHelpSchema>) {
         'a query. Most common failure: `created` exists on case/defect/plan/requirement but ' +
         'NOT on run (started/ended) or result (ended only).',
       countWithoutPaging:
-        'To count or aggregate, use SELECT (COUNT(id)) rather than paging through rows — ' +
-        'see the `aggregation` topic.',
+        'To count or aggregate, lead with SELECT (COUNT(id)) rather than paging through rows — ' +
+        'e.g. SELECT (COUNT(id)) entity = "result" and project = "DEMO". See the `aggregation` ' +
+        'topic.',
     },
     syntax: {
       basicStructure: 'entity = "TYPE" and CONDITION [and CONDITION...]',
@@ -213,14 +216,15 @@ async function getQqlHelp(args: z.infer<typeof GetQqlHelpSchema>) {
         'QQL can aggregate server-side instead of making you page through rows and count them.',
       functions: ['COUNT', 'MIN', 'MAX', 'AVG', 'SUM', 'FIRST', 'LAST'],
       syntax:
-        'SELECT (aggregate[, aggregate...]) [GROUP BY field] [HAVING condition] — the ' +
-        'parentheses after SELECT are MANDATORY; without them the query fails with ' +
-        '"Query is invalid".',
+        'SELECT (aggregate[, aggregate...]) entity = "TYPE" and CONDITION... ' +
+        '[GROUP BY field] [HAVING condition] — two hard requirements: the parentheses ' +
+        'after SELECT are MANDATORY, and SELECT must come FIRST, before the conditions. ' +
+        'Violating either fails with "Query is invalid", which does not say which one.',
       examples: [
-        'entity = "result" and project = "DEMO" and status = "failed" SELECT (COUNT(id))',
-        'entity = "result" and project = "DEMO" SELECT (COUNT(id)) GROUP BY status',
-        'entity = "case" and project = "DEMO" SELECT (COUNT(id)) GROUP BY suite HAVING COUNT(id) > 10',
-        'entity = "result" and project = "DEMO" SELECT (AVG(timeSpent), MAX(timeSpent))',
+        'SELECT (COUNT(id)) entity = "result" and project = "DEMO" and status = "failed"',
+        'SELECT (COUNT(id)) entity = "result" and project = "DEMO" GROUP BY status',
+        'SELECT (COUNT(id)) entity = "case" and project = "DEMO" GROUP BY suite HAVING COUNT(id) > 10',
+        'SELECT (AVG(timeSpent), MAX(timeSpent)) entity = "result" and project = "DEMO"',
       ],
       enumsComeBackAsNumbers:
         'In aggregate results, enum fields are returned as their numeric IDs, not labels: ' +

--- a/src/operations-v2/qql/qql-help.test.ts
+++ b/src/operations-v2/qql/qql-help.test.ts
@@ -28,6 +28,44 @@ function textOf(value: unknown): string {
   return JSON.stringify(value).replace(/\\"/g, '"');
 }
 
+/** Every topic the tool serves, so a check can sweep all of them. */
+const HELP_TOPICS = [
+  'overview',
+  'syntax',
+  'entities',
+  'operators',
+  'functions',
+  'examples',
+  'aggregation',
+  'enumValues',
+] as const;
+
+/**
+ * Collect the strings in a help section that are whole QQL queries, so
+ * assertions about query form don't trip over prose that merely mentions a
+ * clause. A query starts with `entity =` or `SELECT (`.
+ */
+function queryStringsIn(section: unknown): string[] {
+  const found: string[] = [];
+
+  const walk = (value: unknown): void => {
+    if (typeof value === 'string') {
+      if (value.startsWith('entity = ') || value.startsWith('SELECT (')) found.push(value);
+      return;
+    }
+    if (Array.isArray(value)) {
+      value.forEach(walk);
+      return;
+    }
+    if (value && typeof value === 'object') {
+      Object.values(value).forEach(walk);
+    }
+  };
+
+  walk(section);
+  return found;
+}
+
 describe('qql_help — aggregation', () => {
   it('documents aggregation instead of leaving the model to page and count', async () => {
     const { content } = await help('aggregation');
@@ -46,6 +84,37 @@ describe('qql_help — aggregation', () => {
     // Without them the query fails outright — not guessable.
     expect(text).toContain('SELECT (');
     expect(text.toLowerCase()).toContain('mandatory');
+  });
+
+  it('puts SELECT first in every example', async () => {
+    const { content } = await help('aggregation');
+
+    // The API rejects SELECT placed after the conditions with a bare
+    // "Query is invalid", which does not say what is wrong — so an example in
+    // the wrong order is a trap the model cannot get out of.
+    for (const example of (content as any).examples) {
+      expect(example.startsWith('SELECT (')).toBe(true);
+    }
+  });
+
+  it('states that SELECT must come first', async () => {
+    const text = textOf((await help('aggregation')).content);
+
+    expect(text).toContain('SELECT must come FIRST');
+  });
+
+  it('shows no query anywhere in the help with SELECT after the conditions', async () => {
+    // Every topic, not just aggregation: a model may read only one of them, and
+    // examples live in several sections.
+    for (const topic of HELP_TOPICS) {
+      const queries = queryStringsIn((await help(topic)).content);
+
+      for (const query of queries) {
+        if (query.includes('SELECT (')) {
+          expect(query.startsWith('SELECT (')).toBe(true);
+        }
+      }
+    }
   });
 
   it('explains that aggregate enums come back as numbers', async () => {


### PR DESCRIPTION
## Summary
The aggregation examples added in 2.1.0 placed `SELECT (...)` after the conditions. The API rejects that form with a bare `Query is invalid` that does not say what is wrong, so a model copying the form out of `qql_help` cannot recover — the same class of defect 2.1.0 fixed for `created` on `result`, reintroduced one section over.

Working order is `SELECT (...)` first, then the conditions, then `GROUP BY`/`HAVING`.

Three places:
- **`aggregation.examples`** — all four corrected; the change is purely positional, the rest of each query is character-for-character the same.
- **`aggregation.syntax`** — the mandatory parentheses were already documented; the position requirement now sits next to it, with the note that `Query is invalid` does not distinguish the two.
- **`overview.structure`** — filtering and aggregating forms are now shown separately. They don't mix, and the combined single line is what suggested the wrong order in the first place.

Also `overview.countWithoutPaging`, which a model may read on its own, now shows the leading-`SELECT` form rather than just naming `SELECT (COUNT(id))`.

## Test plan
- [x] `npm run build`
- [x] `npm test` — 471 tests, 1 pre-existing skip, all green
- [x] `npm run lint` — 0 errors, pre-existing `any` warnings only
- [x] Regression test walks every query string in every topic and requires that any query containing `SELECT (` starts with it — **verified to fail against the 2.1.0 text** before the fix, so it genuinely catches this defect rather than just passing
- [x] A narrower test asserts each `aggregation.examples` entry starts with `SELECT (`

Note on the stronger option suggested (running help examples against the live API in an integration test): that would catch this class regardless of the error message, but needs a `QASE_API_TOKEN` and a QQL-enabled subscription in CI. Happy to add it behind an env guard like the existing `test:integration` Redis suite — say the word and I'll do it as a follow-up.