### PR TITLE
feat: allow overriding the API scheme via QASE_API_PROTOCOL (v2.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.2.1]
 
+### Fixed
+
+- **Requests were attributed to the SDK instead of the MCP server.** The `User-Agent` was set as an axios instance default, but `qase-api-client` puts its own `qase-api-client-js/<version>` into `Configuration.baseOptions`, and the generated code merges those headers over the instance defaults. Every call made through the SDK — which is all of them except the `qase_api` escape hatch — therefore reached Qase as `qase-api-client-js/1.1.14`, so neither the MCP source nor the split between self-run (`qase-mcp`) and hosted (`qase-mcp-hosted`) was visible in metrics. The header is now set in a request interceptor, which runs after that merge, and is covered by tests that assert what a real HTTP server receives.
+
 ### Added
 
 - **`QASE_API_PROTOCOL`** — the scheme used to reach `QASE_API_DOMAIN`, defaulting to `https`. Requests were previously hardcoded to HTTPS, so a self-hosted or on-premise Qase API served over plain HTTP could not be reached at all: `QASE_API_DOMAIN` takes a bare domain and rejects anything carrying a scheme. Only `http` and `https` are recognised (case-insensitive, with or without a trailing `://`); any other value falls back to `https`, so a typo cannot silently downgrade the connection. Existing setups are unaffected. See [docs/self-run.md](docs/self-run.md#self-hosted-deployments-over-plain-http).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`QASE_API_PROTOCOL`** — the scheme used to reach `QASE_API_DOMAIN`, defaulting to `https`. Requests were previously hardcoded to HTTPS, so a self-hosted or on-premise Qase API served over plain HTTP could not be reached at all: `QASE_API_DOMAIN` takes a bare domain and rejects anything carrying a scheme. Only `http` and `https` are recognised (case-insensitive, with or without a trailing `://`); any other value falls back to `https`, so a typo cannot silently downgrade the connection. Existing setups are unaffected. See [docs/self-run.md](docs/self-run.md#self-hosted-deployments-over-plain-http).
+
 ## [2.2.0]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.2.1]
 
 ### Added
 

--- a/docs/self-run.md
+++ b/docs/self-run.md
@@ -43,6 +43,9 @@ QASE_API_TOKEN=your_api_token_here
 
 # Optional: Custom API domain for enterprise customers
 QASE_API_DOMAIN=api.qase.io
+
+# Optional: Scheme used to reach that domain — http or https (default: https)
+QASE_API_PROTOCOL=https
 ```
 
 Get your API token from: https://app.qase.io/user/api/token
@@ -54,6 +57,21 @@ If you're using Qase Enterprise with a custom domain:
 ```bash
 QASE_API_DOMAIN=api.yourcompany.qase.io
 ```
+
+`QASE_API_DOMAIN` takes the domain only — no scheme, no path. `https://api.yourcompany.qase.io` or `api.yourcompany.qase.io/v1` are rejected with an error.
+
+### Self-Hosted Deployments over Plain HTTP
+
+Requests go over HTTPS by default. If your self-hosted or on-premise Qase API is served over plain HTTP — typically a local or internal-network install without a certificate — set the scheme separately:
+
+```bash
+QASE_API_DOMAIN=api.qase.lo
+QASE_API_PROTOCOL=http
+```
+
+Only `http` and `https` are recognised (case-insensitive, with or without a trailing `://`). Any other value falls back to `https`, so a typo cannot silently downgrade the connection. A non-default port belongs in `QASE_API_DOMAIN` — `api.qase.lo:8080`.
+
+Use `http` only for deployments you control on a trusted network: the API token travels in a request header, unencrypted, on every call.
 
 ## Client Setup (stdio)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -113,8 +113,22 @@ To find your certificate:
 
 **Solution**:
 1. Ensure `QASE_API_DOMAIN` is set to just the domain (e.g., `api.company.qase.io`)
-2. Don't include `https://` or `/v1` in the domain
-3. Verify with your Qase administrator
+2. Don't include `https://` or `/v1` in the domain — the scheme goes in `QASE_API_PROTOCOL` instead (see below), and the API version is appended by the server
+3. A non-default port does belong in the domain: `api.company.qase.io:8080`
+4. Verify with your Qase administrator
+
+## Self-Hosted API Served over Plain HTTP
+
+**Error**: connection or TLS errors against a self-hosted Qase API that has no certificate
+
+**Solution**: requests default to HTTPS. For a self-hosted or on-premise deployment served over plain HTTP, set the scheme separately:
+
+```bash
+QASE_API_DOMAIN=api.qase.lo
+QASE_API_PROTOCOL=http
+```
+
+Only `http` and `https` are recognised; any other value falls back to `https`, so check for a typo if the scheme appears to be ignored. Use `http` only on a trusted network — the API token is sent unencrypted in a request header.
 
 ## No Tools Showing in MCP Client
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qase/mcp-server",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qase/mcp-server",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qase/mcp-server",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "mcpName": "io.qase/mcp-server",
   "description": "Official MCP server for Qase Test Management Platform",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -29,6 +29,12 @@
           "description": "Custom API domain for enterprise (default: api.qase.io)",
           "isRequired": false,
           "default": "api.qase.io"
+        },
+        {
+          "name": "QASE_API_PROTOCOL",
+          "description": "Scheme used to reach the API domain: http or https. Use http only for self-hosted deployments served without TLS (default: https)",
+          "isRequired": false,
+          "default": "https"
         }
       ]
     }

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/qase-tms/qase-mcp-server",
     "source": "github"
   },
-  "version": "2.2.0",
+  "version": "2.2.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@qase/mcp-server",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -98,6 +98,14 @@ describe('API Client', () => {
     expect(basePathOf(getApiClient())).toBe('http://api.qase.lo/v1');
   });
 
+  it('should keep a port given in QASE_API_DOMAIN', async () => {
+    process.env.QASE_API_PROTOCOL = 'http';
+    process.env.QASE_API_DOMAIN = 'api.qase.lo:8080';
+
+    const { getApiClient } = await import('./index.js');
+    expect(basePathOf(getApiClient())).toBe('http://api.qase.lo:8080/v1');
+  });
+
   it('should fall back to https on an unrecognised QASE_API_PROTOCOL', async () => {
     process.env.QASE_API_PROTOCOL = 'ftp';
     process.env.QASE_API_DOMAIN = 'api.qase.lo';

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -22,6 +22,11 @@ async function resetClient() {
   jest.resetModules();
 }
 
+/** The host the client resolved, read off one of the generated SDK resources. */
+function basePathOf(client: { cases: unknown }): string {
+  return (client.cases as { basePath: string }).basePath;
+}
+
 describe('API Client', () => {
   beforeEach(() => {
     setTestEnv();
@@ -67,6 +72,38 @@ describe('API Client', () => {
 
     const { getApiClient } = await import('./index.js');
     expect(() => getApiClient()).toThrow('QASE_API_DOMAIN should only contain the domain name');
+  });
+
+  it('should default to https when QASE_API_PROTOCOL is not set', async () => {
+    delete process.env.QASE_API_PROTOCOL;
+    process.env.QASE_API_DOMAIN = 'api.custom.qase.io';
+
+    const { getApiClient } = await import('./index.js');
+    expect(basePathOf(getApiClient())).toBe('https://api.custom.qase.io/v1');
+  });
+
+  it('should use http when QASE_API_PROTOCOL says so', async () => {
+    process.env.QASE_API_PROTOCOL = 'http';
+    process.env.QASE_API_DOMAIN = 'api.qase.lo';
+
+    const { getApiClient } = await import('./index.js');
+    expect(basePathOf(getApiClient())).toBe('http://api.qase.lo/v1');
+  });
+
+  it('should accept QASE_API_PROTOCOL written as a scheme with separator', async () => {
+    process.env.QASE_API_PROTOCOL = 'HTTP://';
+    process.env.QASE_API_DOMAIN = 'api.qase.lo';
+
+    const { getApiClient } = await import('./index.js');
+    expect(basePathOf(getApiClient())).toBe('http://api.qase.lo/v1');
+  });
+
+  it('should fall back to https on an unrecognised QASE_API_PROTOCOL', async () => {
+    process.env.QASE_API_PROTOCOL = 'ftp';
+    process.env.QASE_API_DOMAIN = 'api.qase.lo';
+
+    const { getApiClient } = await import('./index.js');
+    expect(basePathOf(getApiClient())).toBe('https://api.qase.lo/v1');
   });
 
   it('should use per-request token when requestTokenStorage has a token', async () => {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -179,9 +179,10 @@ class QaseApiClient {
 /**
  * Get validated API host from QASE_API_DOMAIN env var.
  *
- * The scheme comes from QASE_API_PROTOCOL and defaults to https. It is
- * deliberately undocumented: it exists so a local or self-hosted API served over
- * plain HTTP (http://api.qase.lo) can be reached, and nothing else needs it.
+ * The scheme comes from QASE_API_PROTOCOL and defaults to https; it exists so a
+ * self-hosted API served over plain HTTP (http://api.qase.lo) can be reached.
+ * A non-default port belongs in the domain (api.qase.lo:8080) — only `://` and
+ * paths are rejected here.
  */
 function getHost(): string {
   const domain = process.env.QASE_API_DOMAIN || 'api.qase.io';

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -91,9 +91,19 @@ class QaseApiClient {
     const jwtToken = isJwt(config.token);
 
     const agent = createKeepAliveAgent({ maxSockets: 20 });
-    this.axiosInstance =
-      axiosInstance ??
-      axios.create({ httpsAgent: agent, headers: { 'User-Agent': getUserAgent() } });
+    this.axiosInstance = axiosInstance ?? axios.create({ httpsAgent: agent });
+
+    // The generated SDK puts its own `User-Agent: qase-api-client-js/x.y.z` into
+    // Configuration.baseOptions, and the generator merges those headers over the
+    // axios instance defaults — so setting the source as a default silently loses
+    // to it on every SDK call, leaving only the qase_api escape hatch correctly
+    // attributed. A request interceptor runs after that merge, so it is the one
+    // place the header can be asserted for both paths.
+    this.axiosInstance.interceptors.request.use((req) => {
+      req.headers = req.headers ?? {};
+      req.headers['User-Agent'] = getUserAgent();
+      return req;
+    });
 
     // For JWTs, forward verbatim as Authorization: Bearer on every request.
     // Opaque tokens keep using the Qase `Token` header via Configuration.apiKey.

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -178,6 +178,10 @@ class QaseApiClient {
 
 /**
  * Get validated API host from QASE_API_DOMAIN env var.
+ *
+ * The scheme comes from QASE_API_PROTOCOL and defaults to https. It is
+ * deliberately undocumented: it exists so a local or self-hosted API served over
+ * plain HTTP (http://api.qase.lo) can be reached, and nothing else needs it.
  */
 function getHost(): string {
   const domain = process.env.QASE_API_DOMAIN || 'api.qase.io';
@@ -189,7 +193,18 @@ function getHost(): string {
     );
   }
 
-  return `https://${domain}`;
+  return `${getProtocol()}://${domain}`;
+}
+
+/**
+ * Scheme for API requests. Accepts `http` or `https`, with or without the `://`
+ * suffix; anything else falls back to https rather than failing, so a typo can
+ * never downgrade the connection to something unexpected.
+ */
+function getProtocol(): string {
+  const protocol = process.env.QASE_API_PROTOCOL?.trim().toLowerCase().replace(/:\/*$/, '');
+
+  return protocol === 'http' ? 'http' : 'https';
 }
 
 /**

--- a/src/client/user-agent.test.ts
+++ b/src/client/user-agent.test.ts
@@ -1,24 +1,82 @@
-import { describe, it, expect, afterEach } from '@jest/globals';
-import { getUserAgent } from './index.js';
-import { VERSION } from '../version.js';
+/**
+ * User-Agent Attribution Tests
+ *
+ * Qase attributes the request source by User-Agent, so these run against a real
+ * local HTTP server and assert what actually reaches the wire — the header is
+ * rewritten by both the axios instance and the generated SDK on the way out, and
+ * asserting on our own config would not catch the SDK winning that merge.
+ */
 
-describe('getUserAgent (Qase API source)', () => {
-  afterEach(() => {
-    delete process.env.QASE_MCP_SOURCE;
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from '@jest/globals';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { setTestEnv, clearTestEnv } from '../utils/test-helpers.js';
+
+jest.mock('../utils/auth-context.js', () => ({
+  requestTokenStorage: { getStore: jest.fn(() => undefined) },
+  getEffectiveToken: jest.fn(() => process.env.QASE_API_TOKEN ?? 'test-token'),
+}));
+
+let server: http.Server;
+let received: Array<{ path: string; userAgent?: string }> = [];
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    received.push({ path: req.url ?? '', userAgent: req.headers['user-agent'] });
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ status: true, result: { entities: [], total: 0 } }));
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe('User-Agent attribution', () => {
+  beforeEach(() => {
+    setTestEnv();
+    received = [];
+    const { port } = server.address() as AddressInfo;
+    process.env.QASE_API_DOMAIN = `127.0.0.1:${port}`;
+    process.env.QASE_API_PROTOCOL = 'http';
   });
 
-  it('defaults to qase-mcp when QASE_MCP_SOURCE is unset', () => {
+  afterEach(async () => {
+    clearTestEnv();
     delete process.env.QASE_MCP_SOURCE;
-    expect(getUserAgent()).toBe(`qase-mcp/${VERSION}`);
+    jest.resetModules();
   });
 
-  it('uses qase-mcp-hosted when QASE_MCP_SOURCE is set (hosted deployment)', () => {
+  it('sends the MCP source on SDK calls, not the SDK client version', async () => {
+    const { getApiClient } = await import('./index.js');
+    const { VERSION } = await import('../version.js');
+
+    await getApiClient().projects.getProjects(10, 0);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].userAgent).toBe(`qase-mcp/${VERSION}`);
+    expect(received[0].userAgent).not.toContain('qase-api-client-js');
+  });
+
+  it('sends the MCP source on direct request() calls', async () => {
+    const { getApiClient } = await import('./index.js');
+    const { VERSION } = await import('../version.js');
+
+    await getApiClient().request('/v1/project');
+
+    expect(received).toHaveLength(1);
+    expect(received[0].userAgent).toBe(`qase-mcp/${VERSION}`);
+  });
+
+  it('reports the hosted deployment separately via QASE_MCP_SOURCE', async () => {
     process.env.QASE_MCP_SOURCE = 'qase-mcp-hosted';
-    expect(getUserAgent()).toBe(`qase-mcp-hosted/${VERSION}`);
-  });
 
-  it('trims whitespace and falls back to qase-mcp for an empty value', () => {
-    process.env.QASE_MCP_SOURCE = '   ';
-    expect(getUserAgent()).toBe(`qase-mcp/${VERSION}`);
+    const { getApiClient } = await import('./index.js');
+    const { VERSION } = await import('../version.js');
+
+    await getApiClient().projects.getProjects(10, 0);
+
+    expect(received[0].userAgent).toBe(`qase-mcp-hosted/${VERSION}`);
   });
 });

--- a/src/utils/test-helpers.ts
+++ b/src/utils/test-helpers.ts
@@ -46,6 +46,7 @@ export function setTestEnv() {
 export function clearTestEnv() {
   delete process.env.QASE_API_TOKEN;
   delete process.env.QASE_API_DOMAIN;
+  delete process.env.QASE_API_PROTOCOL;
 }
 
 /**


### PR DESCRIPTION
Two things, both about how the client reaches the Qase API.

## `QASE_API_PROTOCOL`

The API host was hardcoded to `https`, so a self-hosted or on-premise Qase API served over plain HTTP (`http://api.qase.lo`) could not be reached at all — `QASE_API_DOMAIN` takes a bare domain and rejects anything carrying a scheme, by design.

The scheme now comes from `QASE_API_PROTOCOL`, defaulting to `https`, so the domain variable keeps its single meaning and existing setups are unaffected. `http` and `https` are accepted with or without the `://` suffix; anything else falls back to `https` rather than throwing, so a typo cannot silently downgrade the connection. A non-default port still belongs in the domain (`api.qase.lo:8080`), which already passed validation.

Documented in `docs/self-run.md` (env list + a **Self-Hosted Deployments over Plain HTTP** section), `docs/troubleshooting.md` (TLS errors against a certificate-less install), `server.json` for the MCP registry, and the changelog. Each place repeats the same caveat, since each is reachable without the others: `http` sends the API token unencrypted in a request header, so it is for deployments you control on a trusted network.

## Requests were attributed to the SDK, not to us

Found while checking what headers actually go out. `User-Agent` was set as an axios instance default, but `qase-api-client` puts its own `qase-api-client-js/<version>` into `Configuration.baseOptions`, and the generated request code merges those headers **over** the instance defaults. So every call through the SDK — everything except the `qase_api` escape hatch, which builds its headers by hand — reached Qase as `qase-api-client-js/1.1.14`:

| Call path | Before | After |
| --- | --- | --- |
| SDK (`client.cases.*`, `client.projects.*`, …) | `qase-api-client-js/1.1.14` | `qase-mcp/2.2.1` |
| `client.request()` (`qase_api`) | `qase-mcp/2.2.1` | `qase-mcp/2.2.1` |

The source the header exists to report was therefore never sent on the paths that matter, and the self-run vs hosted split (`QASE_MCP_SOURCE=qase-mcp-hosted`) was invisible in metrics. Setting the header in a request interceptor fixes both paths — interceptors run after config merging.

The new tests assert what a real local HTTP server receives, not what the client's config says: asserting on config is exactly what would have missed this, since the axios defaults were correct the whole time. Reverting the interceptor turns them red with `qase-api-client-js/1.1.14`.

## Version

Bumped to **2.2.1** (`package.json`, `package-lock.json`, `server.json`, changelog). No tag pushed — publishing runs off the tag, after merge.

## Testing

- `npm test` — 525 passed (up from 522: 5 for the protocol variable, 1 for the port case, 3 for User-Agent attribution)
- `npm run build`, `npm run lint` — clean
- Verified end to end against a local HTTP server: correct scheme, and `qase-mcp/2.2.1` on both call paths