### PR TITLE
docs: state that the hosted connector serves the main cloud only

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ See [Tools](#tools) and [docs/tools.md](docs/tools.md) for the full reference.
 
 No install, no API token — connect to the Qase-hosted server and sign in with your Qase account.
 
-> **Note:** The hosted Qase MCP is available on the **Enterprise** plan in Qase. On other plans, [run the server yourself](#run-it-yourself) with your own API token.
+> **Note:** The hosted Qase MCP requires the **Enterprise** plan *and* a workspace on Qase's main cloud (`qase.io`). On another plan, or on a dedicated instance, [run the server yourself](#run-it-yourself) with your own API token — that works everywhere.
 
 - **Claude** — open **Settings → Connectors**, find **Qase Test Management**, click **Connect**.
 - **Cursor** — add `{"mcpServers": {"qase": {"url": "https://mcp.qase.io/mcp"}}}` to `.cursor/mcp.json`.

--- a/docs/connect.md
+++ b/docs/connect.md
@@ -2,7 +2,12 @@
 
 The quickest way to use Qase — no install and no API token. Connect to the Qase-hosted MCP server at `https://mcp.qase.io/mcp` and sign in with your Qase account. Any MCP client that supports remote servers (OAuth 2.1) works; the client handles the OAuth flow for you — Claude, Cursor, Codex, and VS Code are shown below.
 
-> **Note:** The hosted Qase MCP is available on the **Enterprise** plan in Qase. On other plans you'll be denied access when connecting — [run the server yourself](self-run.md) with your own API token instead.
+> **Availability:** The hosted Qase MCP requires the **Enterprise** plan *and* a workspace on Qase's main cloud (`qase.io`). Two situations call for [running the server yourself](self-run.md) instead:
+>
+> - **Any other plan** — you can sign in, but tool calls are rejected with a plan error.
+> - **A dedicated instance** — the hosted server only talks to the main cloud, so it cannot reach a dedicated deployment whatever your plan. Self-run points at your own domain via `QASE_API_DOMAIN`.
+>
+> Running the server yourself works on every plan and on both cloud and dedicated instances.
 
 Prefer to run the server yourself with your own `QASE_API_TOKEN`? See [Self-Run Guide (Local / stdio)](self-run.md).
 

--- a/docs/self-run.md
+++ b/docs/self-run.md
@@ -60,6 +60,8 @@ QASE_API_DOMAIN=api.yourcompany.qase.io
 
 `QASE_API_DOMAIN` takes the domain only — no scheme, no path. `https://api.yourcompany.qase.io` or `api.yourcompany.qase.io/v1` are rejected with an error.
 
+If your workspace is on a **dedicated instance**, self-run is the only option: the [hosted connector](connect.md) serves Qase's main cloud (`qase.io`) only, regardless of plan.
+
 ### Self-Hosted Deployments over Plain HTTP
 
 Requests go over HTTPS by default. If your self-hosted or on-premise Qase API is served over plain HTTP — typically a local or internal-network install without a certificate — set the scheme separately:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -20,9 +20,22 @@ These apply when connecting to the Qase-hosted server (`https://mcp.qase.io/mcp`
 
 ### Access denied / Enterprise plan required
 
-The hosted Qase MCP is available on the **Enterprise** plan in Qase. If your workspace is on another plan, requests are rejected with an access/plan error — the connector may sign in but tool calls fail with a plan-related message.
+The hosted Qase MCP requires the **Enterprise** plan. If your workspace is on another plan, requests are rejected with an access/plan error — the connector may sign in but tool calls fail with a plan-related message.
 
 **Solution**: upgrade to the Enterprise plan, or [run the server yourself](self-run.md) with your own `QASE_API_TOKEN` (works on any plan).
+
+### Dedicated instance can't use the hosted connector
+
+The hosted server at `https://mcp.qase.io/mcp` serves Qase's main cloud (`qase.io`) only. If your workspace lives on a dedicated instance, the connector cannot reach your data — an Enterprise plan does not change this, and the symptom is usually a sign-in that succeeds against the wrong place, or projects that simply aren't there.
+
+**Solution**: [run the server yourself](self-run.md) and point it at your instance:
+
+```bash
+QASE_API_TOKEN=your_api_token_here
+QASE_API_DOMAIN=api.yourcompany.qase.io
+```
+
+If that instance is served without TLS, also set `QASE_API_PROTOCOL=http` — see [Self-Hosted API Served over Plain HTTP](#self-hosted-api-served-over-plain-http).
 
 ### Connector doesn't appear, or won't connect
 


### PR DESCRIPTION
Availability of the hosted connector was documented as a plan requirement alone. It is actually two conditions:

1. the **Enterprise** plan, and
2. a workspace on Qase's main cloud (`qase.io`).

So a dedicated instance on the Enterprise plan read every page as "the hosted connector is for you" — it isn't. The hosted server at `https://mcp.qase.io/mcp` talks to the main cloud only, and no plan changes that; those customers have to self-run with `QASE_API_DOMAIN` pointed at their own instance.

## Changes

- **`README.md`**, **`docs/connect.md`** — the availability note now states both conditions and names self-run as the path that works everywhere.
- **`docs/troubleshooting.md`** — the existing entry keeps covering the plan error; a new **Dedicated instance can't use the hosted connector** section covers the other case. It needed its own entry because the symptom isn't an access error: the sign-in succeeds and the projects simply aren't there, which nothing in the old text explained. Links on to `QASE_API_PROTOCOL` for instances served without TLS.
- **`docs/self-run.md`** — same point from the other side, next to the custom-domain setup a dedicated instance needs anyway.

Docs only — no code, no version change.