### PR TITLE
docs: use the api-<cluster>.qase.io form for dedicated instances

### DIFF
--- a/docs/self-run.md
+++ b/docs/self-run.md
@@ -55,10 +55,10 @@ Get your API token from: https://app.qase.io/user/api/token
 If you're using Qase Enterprise with a custom domain:
 
 ```bash
-QASE_API_DOMAIN=api.yourcompany.qase.io
+QASE_API_DOMAIN=api-yourcompany.qase.io
 ```
 
-`QASE_API_DOMAIN` takes the domain only — no scheme, no path. `https://api.yourcompany.qase.io` or `api.yourcompany.qase.io/v1` are rejected with an error.
+`QASE_API_DOMAIN` takes the domain only — no scheme, no path. `https://api-yourcompany.qase.io` or `api-yourcompany.qase.io/v1` are rejected with an error.
 
 If your workspace is on a **dedicated instance**, self-run is the only option: the [hosted connector](connect.md) serves Qase's main cloud (`qase.io`) only, regardless of plan.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -32,7 +32,7 @@ The hosted server at `https://mcp.qase.io/mcp` serves Qase's main cloud (`qase.i
 
 ```bash
 QASE_API_TOKEN=your_api_token_here
-QASE_API_DOMAIN=api.yourcompany.qase.io
+QASE_API_DOMAIN=api-yourcompany.qase.io
 ```
 
 If that instance is served without TLS, also set `QASE_API_PROTOCOL=http` — see [Self-Hosted API Served over Plain HTTP](#self-hosted-api-served-over-plain-http).
@@ -125,9 +125,9 @@ To find your certificate:
 **Error**: `Invalid domain` or connection errors with custom domain
 
 **Solution**:
-1. Ensure `QASE_API_DOMAIN` is set to just the domain (e.g., `api.company.qase.io`)
+1. Ensure `QASE_API_DOMAIN` is set to just the domain (e.g., `api-company.qase.io`)
 2. Don't include `https://` or `/v1` in the domain — the scheme goes in `QASE_API_PROTOCOL` instead (see below), and the API version is appended by the server
-3. A non-default port does belong in the domain: `api.company.qase.io:8080`
+3. A non-default port does belong in the domain: `api-company.qase.io:8080`
 4. Verify with your Qase administrator
 
 ## Self-Hosted API Served over Plain HTTP


### PR DESCRIPTION
Every custom-domain example in the docs showed a dedicated instance as `api.yourcompany.qase.io`. The real form is `api-yourcompany.qase.io` — a hyphen after `api`, not a subdomain under the customer's name — so anyone copying an example got a host that doesn't resolve to their instance.

| File | Before | After |
| --- | --- | --- |
| `docs/self-run.md` | `QASE_API_DOMAIN=api.yourcompany.qase.io` | `api-yourcompany.qase.io` |
| `docs/self-run.md` | rejected-value examples (`https://…`, `…/v1`) | same, hyphenated |
| `docs/troubleshooting.md` | dedicated-instance snippet | `api-yourcompany.qase.io` |
| `docs/troubleshooting.md` | Custom Domain Issues, incl. the port example | `api-company.qase.io`, `api-company.qase.io:8080` |

`api.qase.io` (main cloud) and `api.qase.lo` (local instance example) are untouched — those are correct as they stand.

Follow-up to #77, which landed the availability rules themselves. Docs only.