### PR TITLE
feat: forward a client-supplied integration marker to the Qase API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2]
+
+### Added
+
+- **Integration marker** — a product built on top of this server (a plugin, an agent, a wrapper CLI) can identify itself, and the server forwards that identity to the Qase API as `X-MCP-Integration-Name` / `X-MCP-Integration-Version`. This is a third identity axis, independent of the two already on the wire: the `User-Agent` says which deployment of the server is running (`qase-mcp` vs `qase-mcp-hosted`), `X-MCP-Client-*` says which AI host is connected — neither can carry it, since the same integration runs on any host, on either deployment. Set `QASE_MCP_INTEGRATION=<name>/<version>` (version optional); over HTTP transports the marker can instead travel per request, as an `X-Qase-Integration` header or `?integration=` on the MCP endpoint (captured when the session is created, then remembered for it). Precedence: request header → session value → env var. The name must be on the allowlist in `src/utils/integration-marker.ts`, which bounds the cardinality of the analytics dimension — anything unlisted, malformed or oversized is dropped silently and the API call still succeeds. Nothing is sent when no marker is supplied, so existing setups are byte-for-byte unaffected on the wire. For integration authors only; see [docs/self-run.md](docs/self-run.md#integration-marker-for-integration-authors).
+
+### Security
+
+- Raised the dev-dependency `overrides` to clear all open Dependabot alerts: `js-yaml` to 3.15.1 / 4.3.1 (quadratic-CPU DoS in merge-key and `!!omap` handling), `@babel/core` to ^7.29.6 (arbitrary file read via a `sourceMappingURL` comment), and `yaml` to ^2.8.3 (stack overflow on deeply nested collections). All four are development-only and reached the tree through eslint, jest and lint-staged — `npm audit --omit=dev` already reported zero, so nothing shipped to consumers of the package was affected. Note that the previous `js-yaml@3` override pinned 3.14.2, which was itself vulnerable.
+
 ## [2.2.1]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Official [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server 
 - [Quick Start](#quick-start)
   - [Use the hosted Qase MCP (recommended)](#use-the-hosted-qase-mcp-recommended)
   - [Run it yourself](#run-it-yourself)
+- [Building on top of this server](#building-on-top-of-this-server)
 - [Upgrading from v1](#upgrading-from-v1)
 - [Tools](#tools)
 - [Documentation](#documentation)
@@ -74,6 +75,18 @@ export QASE_API_TOKEN=your_api_token_here
 ```
 
 Then point your MCP client's stdio config at the `@qase/mcp-server` binary. Full install options, client configs (Claude Desktop, Cursor, Claude Code, Codex, OpenCode), environment variables, and transports (stdio/SSE/streamable-HTTP): **[docs/self-run.md](docs/self-run.md)**.
+
+## Building on top of this server
+
+For **integration authors** only — if you use the server directly, nothing here applies to you.
+
+If your product drives this server (a plugin, an agent, a wrapper CLI), it can identify itself so its usage is attributable in Qase analytics, independently of which AI host is connected:
+
+```bash
+QASE_MCP_INTEGRATION=quality-supervisor/1.4.0   # <name>/<version>, version optional
+```
+
+The name must be on the allowlist in [`src/utils/integration-marker.ts`](src/utils/integration-marker.ts) — add yours in a PR. Anything unlisted or malformed is ignored, and the API call still succeeds. HTTP transports also accept the marker per request (`X-Qase-Integration` header or `?integration=`). Details: **[docs/self-run.md](docs/self-run.md#integration-marker-for-integration-authors)**.
 
 ## Upgrading from v1
 

--- a/docs/self-run.md
+++ b/docs/self-run.md
@@ -50,6 +50,28 @@ QASE_API_PROTOCOL=https
 
 Get your API token from: https://app.qase.io/user/api/token
 
+### Integration Marker (for integration authors)
+
+Skip this section if you are using the server directly — it changes nothing for you.
+
+If you are *building a product on top of* this server (a plugin, an agent, a wrapper CLI), you can have your integration identified in Qase analytics. Set `QASE_MCP_INTEGRATION` in the environment you launch the server with:
+
+```bash
+# <name>/<version> — the version is optional
+QASE_MCP_INTEGRATION=quality-supervisor/1.4.0
+```
+
+The server forwards it to the Qase API as `X-MCP-Integration-Name` and `X-MCP-Integration-Version`. It is a separate identity from the server deployment (`User-Agent`) and from the connected AI host (`X-MCP-Client-*`), so the same integration is attributable across every host and both deployments.
+
+Rules:
+
+- Format is `<name>/<version>`; the version may be omitted. The name is lowercased.
+- A version must be made of word characters, dots, dashes or pluses, up to 32 characters — anything else is dropped and only the name is sent.
+- **The name must be on the allowlist** in [`src/utils/integration-marker.ts`](../src/utils/integration-marker.ts) (`ALLOWED_INTEGRATIONS`). This bounds the cardinality of the analytics dimension, so an unlisted name is ignored entirely and nothing is sent. To add your integration, open a PR adding it to that array.
+- A malformed or unlisted marker is dropped silently; the API call itself still succeeds.
+
+Over HTTP transports the marker can also travel per request instead of per process — send an `X-Qase-Integration: <name>/<version>` header, or add `?integration=<name>/<version>` to the MCP endpoint URL (read when the session is created, then remembered for that session). The query parameter is the fallback for clients that do not pass custom headers through. Precedence: request header → the value remembered for the session → `QASE_MCP_INTEGRATION`.
+
 ### Custom Domains (Enterprise)
 
 If you're using Qase Enterprise with a custom domain:

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,13 +50,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -65,9 +65,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
-      "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -75,21 +75,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
-      "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.3",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.4",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.4",
-        "@babel/types": "^7.28.4",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -116,14 +116,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
-      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.3",
-        "@babel/types": "^7.28.2",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -133,14 +133,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -170,9 +170,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -180,29 +180,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -222,9 +222,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -232,9 +232,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -242,9 +242,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -252,27 +252,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
-      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.4"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -521,33 +521,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
-      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.3",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.4",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -555,14 +555,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
-      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -877,9 +877,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2642,13 +2642,16 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.14",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.14.tgz",
-      "integrity": "sha512-GM9c0cWWR8Ga7//Ves/9KRgTS8nLausCkP3CGiFLrnwA2CDUluXgaQqvrULoR2Ujrd/mz/lkX87F5BHFsNr5sQ==",
+      "version": "2.11.15",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.15.tgz",
+      "integrity": "sha512-FwMjJJ7HnyZpWe+oWxegG0fezZyBZUagI5LZEoO3GCbtbKNwRfMH9Ue5d5v01PNePBy1QSfPSDTTeVL0Hb9EzA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/body-parser": {
@@ -2741,9 +2744,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.26.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.3.tgz",
-      "integrity": "sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -2761,11 +2764,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.8.9",
-        "caniuse-lite": "^1.0.30001746",
-        "electron-to-chromium": "^1.5.227",
-        "node-releases": "^2.0.21",
-        "update-browserslist-db": "^1.1.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2863,9 +2866,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001749",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001749.tgz",
-      "integrity": "sha512-0rw2fJOmLfnzCRbkm8EyHL8SvI2Apu5UbnQuTsJ0ClgrH8hcwFooJ1s5R0EP8o8aVrFu8++ae29Kt9/gZAZp/Q==",
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
       "dev": true,
       "funding": [
         {
@@ -3363,9 +3366,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.233",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.233.tgz",
-      "integrity": "sha512-iUdTQSf7EFXsDdQsp8MwJz5SVk4APEFqXU/S47OtQ0YLqacSwPXdZ5vRlMX3neb07Cy2vgioNuRnWUXFwuslkg==",
+      "version": "1.5.411",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.411.tgz",
+      "integrity": "sha512-gglkxzokjHfawpGxq75XdBV2/l3BAPzrsMs70qgaZdTW5rpV1tC4MdgJVP9fN126bODA4ZJQkn1wryEzJyQXIg==",
       "dev": true,
       "license": "ISC"
     },
@@ -5517,10 +5520,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6186,11 +6199,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.23",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.23.tgz",
-      "integrity": "sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg==",
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -7724,9 +7740,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
       "dev": true,
       "funding": [
         {
@@ -7895,9 +7911,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -7905,6 +7921,9 @@
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qase/mcp-server",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qase/mcp-server",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,10 @@
     "typescript": "^5.3.3"
   },
   "overrides": {
-    "js-yaml@3": "3.14.2"
+    "js-yaml@3": "3.15.1",
+    "js-yaml@4": "4.3.1",
+    "@babel/core": "^7.29.6",
+    "yaml": "^2.8.3"
   },
   "optionalDependencies": {
     "ioredis": "^5.10.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qase/mcp-server",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "mcpName": "io.qase/mcp-server",
   "description": "Official MCP server for Qase Test Management Platform",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/qase-tms/qase-mcp-server",
     "source": "github"
   },
-  "version": "2.2.1",
+  "version": "2.2.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@qase/mcp-server",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "transport": {
         "type": "stdio"
       },

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -36,6 +36,8 @@ import { isJwt } from '../auth/token-type.js';
 import FormData from 'form-data';
 import { requestTokenStorage, getEffectiveToken } from '../utils/auth-context.js';
 import { getServer } from '../utils/server-context.js';
+import { getIntegration } from '../utils/integration-context.js';
+import { parseIntegrationMarker } from '../utils/integration-marker.js';
 import { VERSION } from '../version.js';
 
 /**
@@ -125,6 +127,25 @@ class QaseApiClient {
         req.headers['X-MCP-Client-Name'] = client.name;
         if (client.version) {
           req.headers['X-MCP-Client-Version'] = client.version;
+        }
+      }
+      return req;
+    });
+
+    // Tag each Qase API request with the integration built on top of this server
+    // (a plugin/agent/wrapper — e.g. the quality-supervisor Claude Code plugin).
+    // A third axis, independent of the User-Agent source and of the AI host in
+    // X-MCP-Client-*: the same integration can run on any host, on either
+    // deployment. Sourced per-request from integrationStorage, falling back to
+    // QASE_MCP_INTEGRATION. Nothing is sent unless the marker is well-formed and
+    // allowlisted — see integration-marker.ts.
+    this.axiosInstance.interceptors.request.use((req) => {
+      const integration = parseIntegrationMarker(getIntegration());
+      if (integration) {
+        req.headers = req.headers ?? {};
+        req.headers['X-MCP-Integration-Name'] = integration.name;
+        if (integration.version) {
+          req.headers['X-MCP-Integration-Version'] = integration.version;
         }
       }
       return req;

--- a/src/client/integration-headers.test.ts
+++ b/src/client/integration-headers.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Integration Marker Attribution Tests
+ *
+ * Like user-agent.test.ts, these run against a real local HTTP server and assert
+ * what actually reaches the wire. The generated SDK merges its own headers over
+ * the axios instance defaults on the way out, so asserting on our own config
+ * would not prove the outbound request is what we think it is — and this axis has
+ * to coexist with two others (the User-Agent source and X-MCP-Client-*) without
+ * disturbing either.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from '@jest/globals';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { QaseApiClient } from './index.js';
+import { VERSION } from '../version.js';
+import { serverStorage } from '../utils/server-context.js';
+import { integrationStorage } from '../utils/integration-context.js';
+
+const OPAQUE = 'opaque-token-123';
+
+let server: http.Server;
+let host: string;
+let received: Array<http.IncomingHttpHeaders> = [];
+
+function serverWithClient(name: string, version: string): Server {
+  return { getClientVersion: () => ({ name, version }) } as unknown as Server;
+}
+
+/** Run an SDK call under a given AI host identity and integration marker. */
+async function call(marker: string | undefined): Promise<void> {
+  const client = new QaseApiClient({ token: OPAQUE, host });
+  const invoke = () => client.projects.getProjects(10, 0);
+  await serverStorage.run(serverWithClient('claude-ai', '1.2.3'), () =>
+    marker === undefined ? invoke() : integrationStorage.run(marker, invoke),
+  );
+}
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    received.push(req.headers);
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ status: true, result: { entities: [], total: 0 } }));
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  host = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+beforeEach(() => {
+  received = [];
+  delete process.env.QASE_MCP_INTEGRATION;
+});
+
+describe('integration marker on the wire', () => {
+  it('adds X-MCP-Integration-* while leaving User-Agent and X-MCP-Client-* untouched', async () => {
+    await call('quality-supervisor/1.4.0');
+
+    expect(received).toHaveLength(1);
+    const headers = received[0];
+
+    // The new axis.
+    expect(headers['x-mcp-integration-name']).toBe('quality-supervisor');
+    expect(headers['x-mcp-integration-version']).toBe('1.4.0');
+
+    // The two existing axes, unchanged. The backend gates hosted access on an
+    // exact-equality check against the User-Agent source, so this must not drift.
+    expect(headers['user-agent']).toBe(`qase-mcp/${VERSION}`);
+    expect(headers['user-agent']).not.toContain('qase-api-client-js');
+    expect(headers['x-mcp-client-name']).toBe('claude-ai');
+    expect(headers['x-mcp-client-version']).toBe('1.2.3');
+  });
+
+  it('sends no integration headers when no marker is supplied', async () => {
+    await call(undefined);
+
+    const headers = received[0];
+    expect(headers['x-mcp-integration-name']).toBeUndefined();
+    expect(headers['x-mcp-integration-version']).toBeUndefined();
+    // The other two axes are unaffected by the marker being absent.
+    expect(headers['user-agent']).toBe(`qase-mcp/${VERSION}`);
+    expect(headers['x-mcp-client-name']).toBe('claude-ai');
+  });
+
+  it('drops a non-allowlisted marker silently and still completes the request', async () => {
+    await call('some-random-plugin/9.9.9');
+
+    expect(received).toHaveLength(1);
+    expect(received[0]['x-mcp-integration-name']).toBeUndefined();
+    expect(received[0]['user-agent']).toBe(`qase-mcp/${VERSION}`);
+  });
+
+  it('sends the name only when the version is malformed', async () => {
+    await call('quality-supervisor/not a version');
+
+    expect(received[0]['x-mcp-integration-name']).toBe('quality-supervisor');
+    expect(received[0]['x-mcp-integration-version']).toBeUndefined();
+  });
+
+  it('falls back to QASE_MCP_INTEGRATION on the stdio path (no request context)', async () => {
+    process.env.QASE_MCP_INTEGRATION = 'quality-supervisor/3.0.0';
+
+    const client = new QaseApiClient({ token: OPAQUE, host });
+    await client.projects.getProjects(10, 0); // outside any integrationStorage scope
+
+    expect(received[0]['x-mcp-integration-name']).toBe('quality-supervisor');
+    expect(received[0]['x-mcp-integration-version']).toBe('3.0.0');
+  });
+
+  it('applies to the direct request() escape hatch too', async () => {
+    const client = new QaseApiClient({ token: OPAQUE, host });
+    await integrationStorage.run('quality-supervisor/1.4.0', () => client.request('/v1/project'));
+
+    expect(received[0]['x-mcp-integration-name']).toBe('quality-supervisor');
+    expect(received[0]['x-mcp-integration-version']).toBe('1.4.0');
+    expect(received[0]['user-agent']).toBe(`qase-mcp/${VERSION}`);
+  });
+});

--- a/src/transports/sse.ts
+++ b/src/transports/sse.ts
@@ -2,6 +2,8 @@ import express, { Express } from 'express';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { requestTokenStorage } from '../utils/auth-context.js';
+import { integrationStorage } from '../utils/integration-context.js';
+import { normalizeIntegrationMarker } from '../utils/integration-marker.js';
 import { getMetrics } from '../cache/index.js';
 
 export interface SSETransportConfig {
@@ -9,6 +11,11 @@ export interface SSETransportConfig {
   host?: string;
   sseEndpoint?: string;
   messagesEndpoint?: string;
+}
+
+/** Normalised integration marker off a header or query value (integration-marker.ts). */
+function readIntegrationMarker(value: unknown): string | undefined {
+  return typeof value === 'string' ? normalizeIntegrationMarker(value) : undefined;
 }
 
 export function setupSSETransport(server: Server, config: SSETransportConfig): Express {
@@ -20,6 +27,10 @@ export function setupSSETransport(server: Server, config: SSETransportConfig): E
   const host = config.host || '0.0.0.0';
 
   let transport: SSEServerTransport | null = null;
+  // This transport serves a single connection at a time, so the marker captured
+  // when the stream is opened plays the role the per-session map plays in
+  // streamable-http: it covers POSTs that cannot repeat the header.
+  let connectionIntegration: string | undefined;
 
   // Health check endpoint
   app.get('/health', (_req, res) => {
@@ -33,8 +44,11 @@ export function setupSSETransport(server: Server, config: SSETransportConfig): E
   });
 
   // SSE endpoint for establishing connection
-  app.get(sseEndpoint, (_req, res) => {
+  app.get(sseEndpoint, (req, res) => {
     console.error('[SSE] Client connected');
+    connectionIntegration =
+      readIntegrationMarker(req.headers['x-qase-integration']) ??
+      readIntegrationMarker(req.query.integration);
     transport = new SSEServerTransport(messagesEndpoint, res);
     server.connect(transport);
   });
@@ -47,7 +61,11 @@ export function setupSSETransport(server: Server, config: SSETransportConfig): E
     }
     const authHeader = (req.headers['authorization'] as string) || '';
     const requestToken = authHeader.startsWith('Bearer ') ? authHeader.slice(7).trim() : '';
-    requestTokenStorage.run(requestToken, () => transport!.handlePostMessage(req, res));
+    const integration =
+      readIntegrationMarker(req.headers['x-qase-integration']) ?? connectionIntegration ?? '';
+    requestTokenStorage.run(requestToken, () =>
+      integrationStorage.run(integration, () => transport!.handlePostMessage(req, res)),
+    );
   });
 
   // Start server

--- a/src/transports/streamableHttp.integration-marker.test.ts
+++ b/src/transports/streamableHttp.integration-marker.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Integration Marker Capture (streamable-http)
+ *
+ * Drives the real Express app so both supported channels are exercised end to
+ * end: the `X-Qase-Integration` request header and the `?integration=` query
+ * parameter on the MCP endpoint. Both exist on purpose — it is not yet proven
+ * that custom headers survive the OAuth flow on the hosted endpoint in every MCP
+ * client, and the query parameter is the fallback.
+ *
+ * The tool handler reports getIntegration(), i.e. what a Qase API call made from
+ * inside that request would actually see.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from '@jest/globals';
+import type http from 'node:http';
+import request from 'supertest';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { getIntegration } from '../utils/integration-context.js';
+
+process.env.QASE_OAUTH_ENABLED = 'false';
+
+let app: ReturnType<typeof import('./streamableHttp.js').setupStreamableHttpTransport>;
+
+function makeServer(): Server {
+  const server = new Server({ name: 'test', version: '0.0.0' }, { capabilities: { tools: {} } });
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [{ name: 'whoami', description: 'reports the integration marker', inputSchema: { type: 'object' } }],
+  }));
+  server.setRequestHandler(CallToolRequestSchema, async () => ({
+    content: [{ type: 'text', text: getIntegration() ?? 'none' }],
+  }));
+  return server;
+}
+
+const ACCEPT = 'application/json, text/event-stream';
+
+/** Initialize a session, optionally with a header and/or a query marker. */
+async function initSession(opts: { header?: string; query?: string } = {}): Promise<string> {
+  let req = request(app).post('/mcp');
+  if (opts.query !== undefined) req = req.query({ integration: opts.query });
+  if (opts.header !== undefined) req = req.set('X-Qase-Integration', opts.header);
+
+  const res = await req.set('Accept', ACCEPT).send({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2025-03-26',
+      capabilities: {},
+      clientInfo: { name: 'test-client', version: '1.0.0' },
+    },
+  });
+
+  expect(res.status).toBe(200);
+  const sessionId = res.headers['mcp-session-id'];
+  expect(typeof sessionId).toBe('string');
+  return sessionId;
+}
+
+/** Call the whoami tool on a session and return the marker it observed. */
+async function whoami(sessionId: string, header?: string): Promise<string> {
+  let req = request(app).post('/mcp').set('mcp-session-id', sessionId);
+  if (header !== undefined) req = req.set('X-Qase-Integration', header);
+
+  const res = await req
+    .set('Accept', ACCEPT)
+    .send({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'whoami', arguments: {} } });
+
+  expect(res.status).toBe(200);
+  return res.body.result.content[0].text;
+}
+
+beforeAll(async () => {
+  const { setupStreamableHttpTransport } = await import('./streamableHttp.js');
+  // port 0 → ephemeral; the app is driven through supertest.
+  app = setupStreamableHttpTransport(makeServer, { port: 0, host: '127.0.0.1', endpoint: '/mcp' });
+});
+
+afterEach(() => {
+  delete process.env.QASE_MCP_INTEGRATION;
+});
+
+afterAll(async () => {
+  // setupStreamableHttpTransport starts a listener; release it so the run ends.
+  const httpServer = (app as unknown as { _httpServer?: http.Server })._httpServer;
+  if (httpServer) await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+});
+
+describe('streamable-http integration marker', () => {
+  it('captures the marker from the ?integration= query parameter at session creation', async () => {
+    const sessionId = await initSession({ query: 'quality-supervisor/1.0.0' });
+    // Later requests carry no marker of their own — the session remembers it.
+    expect(await whoami(sessionId)).toBe('quality-supervisor/1.0.0');
+  });
+
+  it('captures the marker from the X-Qase-Integration request header', async () => {
+    const sessionId = await initSession({ header: 'quality-supervisor/2.0.0' });
+    expect(await whoami(sessionId)).toBe('quality-supervisor/2.0.0');
+  });
+
+  it('accepts the header on any request, not just initialize', async () => {
+    const sessionId = await initSession();
+    expect(await whoami(sessionId, 'quality-supervisor/3.0.0')).toBe('quality-supervisor/3.0.0');
+  });
+
+  it('prefers the request header over the value remembered for the session', async () => {
+    const sessionId = await initSession({ query: 'quality-supervisor/1.0.0' });
+    expect(await whoami(sessionId, 'quality-supervisor/9.9.9')).toBe('quality-supervisor/9.9.9');
+    // …and the session value survives for requests that send no header.
+    expect(await whoami(sessionId)).toBe('quality-supervisor/1.0.0');
+  });
+
+  it('prefers the header over the query parameter when both are present', async () => {
+    const sessionId = await initSession({
+      header: 'quality-supervisor/2.0.0',
+      query: 'quality-supervisor/1.0.0',
+    });
+    expect(await whoami(sessionId)).toBe('quality-supervisor/2.0.0');
+  });
+
+  it('keeps two concurrent sessions with different markers apart', async () => {
+    const [first, second] = await Promise.all([
+      initSession({ query: 'quality-supervisor/1.0.0' }),
+      initSession({ header: 'quality-supervisor/2.0.0' }),
+    ]);
+
+    const [firstMarker, secondMarker] = await Promise.all([whoami(first), whoami(second)]);
+
+    expect(firstMarker).toBe('quality-supervisor/1.0.0');
+    expect(secondMarker).toBe('quality-supervisor/2.0.0');
+  });
+
+  it('does not remember a non-allowlisted or malformed marker', async () => {
+    const sessionId = await initSession({ query: 'some-random-plugin/1.0.0' });
+    expect(await whoami(sessionId, 'not a marker at all')).toBe('none');
+  });
+
+  it('normalises what it remembers to the canonical form', async () => {
+    const sessionId = await initSession({ query: ' Quality-Supervisor / 1.0.0 ' });
+    expect(await whoami(sessionId)).toBe('quality-supervisor/1.0.0');
+  });
+
+  it('lets a session without a marker fall through to QASE_MCP_INTEGRATION', async () => {
+    process.env.QASE_MCP_INTEGRATION = 'quality-supervisor/4.0.0';
+    const sessionId = await initSession();
+    expect(await whoami(sessionId)).toBe('quality-supervisor/4.0.0');
+  });
+});

--- a/src/transports/streamableHttp.ts
+++ b/src/transports/streamableHttp.ts
@@ -4,6 +4,8 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { mcpAuthRouter } from '@modelcontextprotocol/sdk/server/auth/router.js';
 import { randomUUID } from 'crypto';
 import { requestTokenStorage } from '../utils/auth-context.js';
+import { integrationStorage } from '../utils/integration-context.js';
+import { normalizeIntegrationMarker } from '../utils/integration-marker.js';
 import { getMetrics } from '../cache/index.js';
 import { getOAuthConfig, type OAuthConfig } from '../auth/oauth-config.js';
 import { createJwksVerifier, type JwksVerifier } from '../auth/jwks-verifier.js';
@@ -23,6 +25,19 @@ function isInitializeRequest(body: unknown): boolean {
   return (
     typeof body === 'object' && body !== null && 'method' in body && body.method === 'initialize'
   );
+}
+
+/**
+ * Read the integration marker off a request, normalised (see integration-marker.ts).
+ *
+ * Two channels, both required. The header is the primary one; the query parameter
+ * exists because it is not yet proven that custom request headers survive the
+ * OAuth flow on the hosted endpoint in every MCP client, and a URL is the one
+ * thing every client definitely passes through. The query parameter is only read
+ * at session creation — after that the value is remembered per session.
+ */
+function readIntegrationMarker(value: unknown): string | undefined {
+  return typeof value === 'string' ? normalizeIntegrationMarker(value) : undefined;
 }
 
 export function setupStreamableHttpTransport(
@@ -58,9 +73,11 @@ export function setupStreamableHttpTransport(
     res.header('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
     // Mcp-Method / Mcp-Name are required request headers as of MCP spec 2026-07-28
     // (gateway routing without body parsing) — allow them ahead of client adoption.
+    // X-Qase-Integration is ours: without it a browser-based client's preflight
+    // strips the marker and only the ?integration= fallback would work.
     res.header(
       'Access-Control-Allow-Headers',
-      'Content-Type, Authorization, mcp-session-id, Mcp-Method, Mcp-Name',
+      'Content-Type, Authorization, mcp-session-id, Mcp-Method, Mcp-Name, X-Qase-Integration',
     );
     // Expose auth challenge + session id so browser-based MCP clients (Inspector,
     // Claude.ai web) can read them from cross-origin responses. Without this the
@@ -162,6 +179,9 @@ export function setupStreamableHttpTransport(
   const SESSION_TTL_MS = ttlMinutes * 60 * 1000;
   const sessions = new Map<string, StreamableHTTPServerTransport>();
   const sessionLastSeen = new Map<string, number>();
+  // Integration marker captured at session creation (header or ?integration=),
+  // so later requests on the session need not repeat it. Evicted with the session.
+  const sessionIntegrations = new Map<string, string>();
 
   // Periodically evict stale sessions that never sent a DELETE
   const cleanupInterval = setInterval(
@@ -175,6 +195,7 @@ export function setupStreamableHttpTransport(
             sessions.delete(id);
           }
           sessionLastSeen.delete(id);
+          sessionIntegrations.delete(id);
           console.error(`[StreamableHTTP] Evicted stale session: ${id}`);
         }
       }
@@ -214,6 +235,7 @@ export function setupStreamableHttpTransport(
       await transport.close();
       sessions.delete(sessionId);
       sessionLastSeen.delete(sessionId);
+      sessionIntegrations.delete(sessionId);
       console.error(`[StreamableHTTP] Session closed: ${sessionId}`);
       res.status(200).json({ status: 'session closed' });
     } catch (error) {
@@ -264,10 +286,16 @@ export function setupStreamableHttpTransport(
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
     let transport: StreamableHTTPServerTransport;
 
+    // Integration marker on this request, if it carried one.
+    const headerIntegration = readIntegrationMarker(req.headers['x-qase-integration']);
+    // The one remembered for the session, filled in below.
+    let sessionIntegration: string | undefined;
+
     if (sessionId && sessions.has(sessionId)) {
       // Reuse existing transport for this session — bump last-seen
       transport = sessions.get(sessionId)!;
       sessionLastSeen.set(sessionId, Date.now());
+      sessionIntegration = sessionIntegrations.get(sessionId);
     } else if (isInitializeRequest(req.body)) {
       // This is an initialize request - create new session
       const newSessionId = randomUUID();
@@ -279,6 +307,13 @@ export function setupStreamableHttpTransport(
       // Store session and record creation time
       sessions.set(newSessionId, transport);
       sessionLastSeen.set(newSessionId, Date.now());
+
+      // Remember the integration for the life of the session. The query parameter
+      // is only available here, on the initialize request that carries the URL.
+      sessionIntegration = headerIntegration ?? readIntegrationMarker(req.query.integration);
+      if (sessionIntegration) {
+        sessionIntegrations.set(newSessionId, sessionIntegration);
+      }
 
       // Create a fresh Server instance per session — the SDK requires one Server per transport
       await createServer().connect(transport);
@@ -307,10 +342,14 @@ export function setupStreamableHttpTransport(
       console.error('[StreamableHTTP] Using per-request Bearer token');
     }
 
+    // Precedence: this request's header → the value remembered for the session →
+    // (inside getIntegration) the QASE_MCP_INTEGRATION env var.
+    const integration = headerIntegration ?? sessionIntegration ?? '';
+
     // Run the handler inside AsyncLocalStorage context so getApiClient() can read the token
     try {
       await requestTokenStorage.run(requestToken, () =>
-        transport.handleRequest(req, res, req.body),
+        integrationStorage.run(integration, () => transport.handleRequest(req, res, req.body)),
       );
     } catch (error) {
       console.error('[StreamableHTTP] Error handling request:', error);

--- a/src/utils/integration-context.test.ts
+++ b/src/utils/integration-context.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach } from '@jest/globals';
+import { integrationStorage, getIntegration } from './integration-context.js';
+
+afterEach(() => {
+  delete process.env.QASE_MCP_INTEGRATION;
+});
+
+describe('getIntegration', () => {
+  it('returns undefined with no context and no env var', () => {
+    expect(getIntegration()).toBeUndefined();
+  });
+
+  it('returns the request-scoped value', () => {
+    integrationStorage.run('quality-supervisor/1.0.0', () => {
+      expect(getIntegration()).toBe('quality-supervisor/1.0.0');
+    });
+  });
+
+  it('falls back to QASE_MCP_INTEGRATION outside any scope', () => {
+    process.env.QASE_MCP_INTEGRATION = 'quality-supervisor/2.0.0';
+    expect(getIntegration()).toBe('quality-supervisor/2.0.0');
+  });
+
+  it('falls back to the env var when the request carried no marker', () => {
+    process.env.QASE_MCP_INTEGRATION = 'quality-supervisor/2.0.0';
+    integrationStorage.run('', () => {
+      expect(getIntegration()).toBe('quality-supervisor/2.0.0');
+    });
+  });
+
+  it('prefers the request-scoped value over the env var', () => {
+    process.env.QASE_MCP_INTEGRATION = 'quality-supervisor/2.0.0';
+    integrationStorage.run('quality-supervisor/1.0.0', () => {
+      expect(getIntegration()).toBe('quality-supervisor/1.0.0');
+    });
+  });
+
+  it('ignores a whitespace-only env var', () => {
+    process.env.QASE_MCP_INTEGRATION = '   ';
+    expect(getIntegration()).toBeUndefined();
+  });
+
+  it('keeps concurrent scopes isolated from each other', async () => {
+    const observe = (marker: string, delayMs: number) =>
+      integrationStorage.run(marker, async () => {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        return getIntegration();
+      });
+
+    // Interleaved on purpose: the first scope resumes after the second has run.
+    const [first, second] = await Promise.all([
+      observe('quality-supervisor/1.0.0', 20),
+      observe('quality-supervisor/2.0.0', 0),
+    ]);
+
+    expect(first).toBe('quality-supervisor/1.0.0');
+    expect(second).toBe('quality-supervisor/2.0.0');
+  });
+});

--- a/src/utils/integration-context.ts
+++ b/src/utils/integration-context.ts
@@ -1,0 +1,29 @@
+import { AsyncLocalStorage } from 'async_hooks';
+
+/**
+ * Per-request integration marker storage.
+ *
+ * Holds the raw `<name>/<version>` marker supplied by the integration driving
+ * this request (see integration-marker.ts). Empty string means "this request
+ * carried no marker" — fall back to the process-wide QASE_MCP_INTEGRATION.
+ *
+ * Same shape and lifecycle as requestTokenStorage in auth-context.ts: HTTP
+ * transports open a scope per request, so two concurrent sessions with different
+ * markers never observe each other's value.
+ */
+export const integrationStorage = new AsyncLocalStorage<string>();
+
+/**
+ * Read the marker for the current async context: request-scoped value first,
+ * then the QASE_MCP_INTEGRATION env var (the stdio path, where there is no
+ * request to carry a header).
+ *
+ * Returns undefined when neither is set — the common case, and the one that must
+ * leave the outbound request untouched. The value is unvalidated; callers pass it
+ * through parseIntegrationMarker().
+ */
+export function getIntegration(): string | undefined {
+  const requestIntegration = integrationStorage.getStore();
+  if (requestIntegration) return requestIntegration;
+  return process.env.QASE_MCP_INTEGRATION?.trim() || undefined;
+}

--- a/src/utils/integration-marker.test.ts
+++ b/src/utils/integration-marker.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  ALLOWED_INTEGRATIONS,
+  parseIntegrationMarker,
+  normalizeIntegrationMarker,
+} from './integration-marker.js';
+
+describe('parseIntegrationMarker', () => {
+  it('accepts <name>/<version>', () => {
+    expect(parseIntegrationMarker('quality-supervisor/1.2.3')).toEqual({
+      name: 'quality-supervisor',
+      version: '1.2.3',
+    });
+  });
+
+  it('accepts a bare name with no version', () => {
+    expect(parseIntegrationMarker('quality-supervisor')).toEqual({ name: 'quality-supervisor' });
+  });
+
+  it('lowercases the name', () => {
+    expect(parseIntegrationMarker('Quality-Supervisor/1.0.0')).toEqual({
+      name: 'quality-supervisor',
+      version: '1.0.0',
+    });
+  });
+
+  it('trims surrounding whitespace on both parts', () => {
+    expect(parseIntegrationMarker('  quality-supervisor / 1.0.0  ')).toEqual({
+      name: 'quality-supervisor',
+      version: '1.0.0',
+    });
+  });
+
+  it('keeps versions made of word chars, dots, dashes and pluses', () => {
+    for (const version of ['1', '1.0.0', '2.0.0-beta.1', '1.0.0+build_7', 'v1_2']) {
+      expect(parseIntegrationMarker(`quality-supervisor/${version}`)).toEqual({
+        name: 'quality-supervisor',
+        version,
+      });
+    }
+  });
+
+  it('drops a version that fails the pattern but keeps the name', () => {
+    for (const version of ['1.0 0', 'v1;drop', '1.0/2.0', '../etc', 'ünïcode']) {
+      expect(parseIntegrationMarker(`quality-supervisor/${version}`)).toEqual({
+        name: 'quality-supervisor',
+      });
+    }
+  });
+
+  it('drops a version longer than 32 chars', () => {
+    expect(parseIntegrationMarker(`quality-supervisor/${'1'.repeat(33)}`)).toEqual({
+      name: 'quality-supervisor',
+    });
+  });
+
+  it('drops an empty version after the separator', () => {
+    expect(parseIntegrationMarker('quality-supervisor/')).toEqual({ name: 'quality-supervisor' });
+  });
+
+  it('ignores a name that is not allowlisted', () => {
+    expect(parseIntegrationMarker('some-random-plugin/1.0.0')).toBeUndefined();
+    expect(parseIntegrationMarker('quality-supervisor-evil/1.0.0')).toBeUndefined();
+  });
+
+  it('ignores empty, whitespace-only and missing input', () => {
+    expect(parseIntegrationMarker('')).toBeUndefined();
+    expect(parseIntegrationMarker('   ')).toBeUndefined();
+    expect(parseIntegrationMarker(undefined)).toBeUndefined();
+    expect(parseIntegrationMarker(null)).toBeUndefined();
+  });
+
+  it('ignores an oversized name rather than truncating it into a match', () => {
+    // Truncation caps the field at 100 chars; it must not turn a longer string
+    // into an allowlisted name by cutting off the tail.
+    const padded = `quality-supervisor${'x'.repeat(200)}`;
+    expect(parseIntegrationMarker(padded)).toBeUndefined();
+  });
+
+  it('starts the allowlist with quality-supervisor', () => {
+    expect(ALLOWED_INTEGRATIONS).toContain('quality-supervisor');
+  });
+});
+
+describe('normalizeIntegrationMarker', () => {
+  it('re-serialises to the canonical form', () => {
+    expect(normalizeIntegrationMarker(' Quality-Supervisor/1.2.3 ')).toBe(
+      'quality-supervisor/1.2.3',
+    );
+    expect(normalizeIntegrationMarker('quality-supervisor/bad version')).toBe(
+      'quality-supervisor',
+    );
+  });
+
+  it('returns undefined for anything unusable', () => {
+    expect(normalizeIntegrationMarker('nope/1.0.0')).toBeUndefined();
+    expect(normalizeIntegrationMarker(undefined)).toBeUndefined();
+  });
+});

--- a/src/utils/integration-marker.ts
+++ b/src/utils/integration-marker.ts
@@ -1,0 +1,71 @@
+/**
+ * Integration Marker
+ *
+ * An *integration* is a product built on top of this MCP server (a plugin, an
+ * agent, a wrapper CLI) that wants to be attributable in Qase analytics. It is a
+ * third, independent axis from the two identities already on the wire:
+ *
+ *   - `User-Agent: qase-mcp/<v>` — which deployment of this server (self-run vs hosted)
+ *   - `X-MCP-Client-*`          — which AI host is connected (Claude, Cursor, …)
+ *   - `X-MCP-Integration-*`     — which integration is driving the server (this file)
+ *
+ * The allowlist below is the cardinality control: the backend stores whatever it
+ * receives into a PUBLIC_API_CALL analytics dimension and does not guess, so an
+ * unknown marker must never reach it. Adding an integration is a deliberate
+ * change here, in code review.
+ */
+
+/**
+ * Integration names allowed to identify themselves to the Qase API.
+ * Lowercase; anything not listed here is ignored entirely.
+ */
+export const ALLOWED_INTEGRATIONS: readonly string[] = ['quality-supervisor'];
+
+/** Longest name or version we will look at; longer input is truncated, then validated. */
+const MAX_FIELD_LENGTH = 100;
+
+/** Versions are opaque to us — word chars, dots, dashes and pluses only. */
+const VERSION_PATTERN = /^[\w.\-+]{1,32}$/;
+
+export interface IntegrationMarker {
+  /** Lowercased, allowlisted integration name. */
+  name: string;
+  /** Present only when the supplied version passed validation. */
+  version?: string;
+}
+
+/**
+ * Parse a `<name>/<version>` marker (version optional).
+ *
+ * Everything is best-effort and silent: a malformed, oversized or unknown marker
+ * yields `undefined` rather than an error, so a bad marker can never fail the
+ * API call it was attached to. A valid name with an invalid version keeps the
+ * name and drops the version.
+ */
+export function parseIntegrationMarker(
+  raw: string | undefined | null,
+): IntegrationMarker | undefined {
+  const trimmed = raw?.trim();
+  if (!trimmed) return undefined;
+
+  const separator = trimmed.indexOf('/');
+  const rawName = separator === -1 ? trimmed : trimmed.slice(0, separator);
+  const rawVersion = separator === -1 ? '' : trimmed.slice(separator + 1);
+
+  const name = rawName.trim().slice(0, MAX_FIELD_LENGTH).toLowerCase();
+  if (!ALLOWED_INTEGRATIONS.includes(name)) return undefined;
+
+  const version = rawVersion.trim().slice(0, MAX_FIELD_LENGTH);
+  return VERSION_PATTERN.test(version) ? { name, version } : { name };
+}
+
+/**
+ * Parse and re-serialise a marker into its canonical `<name>[/<version>]` form,
+ * or `undefined` if it is not usable. Transports use this to normalise a marker
+ * once, at the edge, so nothing unbounded or unknown is remembered per session.
+ */
+export function normalizeIntegrationMarker(raw: string | undefined | null): string | undefined {
+  const marker = parseIntegrationMarker(raw);
+  if (!marker) return undefined;
+  return marker.version ? `${marker.name}/${marker.version}` : marker.name;
+}


### PR DESCRIPTION
Lets an integration built on top of this server identify itself, and forwards that identity to the Qase API as `X-MCP-Integration-Name` / `X-MCP-Integration-Version` — headers the backend already reads into its `PUBLIC_API_CALL` analytics event. First consumer: the `quality-supervisor` Claude Code plugin.

### Why a third axis

Neither existing identity can carry it:

- `User-Agent: qase-mcp/<v>` — which **deployment** is running. The backend compares `qase-mcp-hosted` by exact equality to gate hosted access, so that value cannot absorb anything else.
- `X-MCP-Client-*` — which **AI host** is connected. The integration is not the host: the same integration runs on any host, on either deployment.

### How a marker is supplied

Format `<name>/<version>`, version optional. Three channels, in precedence order:

1. `X-Qase-Integration` request header (HTTP transports)
2. `?integration=` on the MCP endpoint — captured at session creation, then remembered for that session
3. `QASE_MCP_INTEGRATION` env var (the stdio path)

Both HTTP channels are kept on purpose: it is not yet proven that custom headers survive the OAuth flow on the hosted endpoint in every MCP client, and the query parameter is the fallback.

### Allowlist lives server-side

`ALLOWED_INTEGRATIONS` in `src/utils/integration-marker.ts`, starting with `quality-supervisor`. These values become an analytics dimension and the backend stores what it receives without guessing, so cardinality has to be bounded before the request goes out. Adding an integration is a PR, not a string a caller can invent. Anything unlisted, malformed or oversized is dropped silently and the API call still succeeds.

### Guarantees

- No `X-MCP-Integration-*` headers when no marker is supplied — outbound requests are byte-for-byte what 2.2.1 sent.
- `User-Agent` and `X-MCP-Client-*` untouched, asserted in the same wire-level test.
- Concurrent sessions with different markers never see each other's value (AsyncLocalStorage nested inside the existing token storage).

### Also in this PR

- **`build:`** dev-dependency `overrides` raised to clear all 7 open Dependabot alerts — `js-yaml` 3.15.1 / 4.3.1, `@babel/core` ^7.29.6, `yaml` ^2.8.3. All development-only (eslint, jest, lint-staged); `npm audit --omit=dev` already reported zero, so nothing shipped to consumers was affected. Note the previous `js-yaml@3` override pinned 3.14.2, itself vulnerable. Independent of the feature — cherry-pick out if you'd rather review it separately.
- **`chore:`** release 2.2.2. Patch rather than minor: no behaviour changes for anyone using the server directly, and the dependency bumps are dev-only.

### Tests

New: `integration-marker` (parse/validate rules), `integration-context` (precedence + concurrency), `integration-headers` (wire-level, against a real HTTP server, following `user-agent.test.ts`), `streamableHttp.integration-marker` (both channels end to end through the real Express app, session isolation).

```
npm run lint  → 0 errors
npm test      → 561 passed, 1 skipped, 44 suites
npm run build → ok
npm audit     → 0 vulnerabilities
```

`sse.ts` gets the same treatment (~15 lines), so the two HTTP transports don't diverge.
