### PR TITLE
docs: say Teams, not Business, for the QQL plan gate

### DIFF
--- a/examples/qql-queries.md
+++ b/examples/qql-queries.md
@@ -12,7 +12,7 @@ QQL (Qase Query Language) is a powerful query language for searching across Qase
 - Sort and limit results
 - Search test cases, runs, results, defects, and more
 
-**Note:** QQL search requires a Business or Enterprise Qase subscription.
+**Note:** QQL search requires a Teams or Enterprise Qase subscription.
 
 ## Getting Help with QQL
 
@@ -495,7 +495,7 @@ Find old non-automated tests → Prioritize for automation → Update custom fie
 
 ### Common Issues
 
-**Error: "QQL search requires Business or Enterprise subscription"**
+**Error: "QQL search requires Teams or Enterprise subscription"**
 - Solution: Upgrade your Qase plan or use standard list/filter tools
 
 **Error: "Unknown field: fieldname"**

--- a/src/operations-v2/qql/index.ts
+++ b/src/operations-v2/qql/index.ts
@@ -153,7 +153,7 @@ async function getQqlHelp(args: z.infer<typeof GetQqlHelpSchema>) {
         'Aggregating: SELECT (AGGREGATE[, ...]) entity = "TYPE" and CONDITION... ' +
         '[GROUP BY field] [HAVING condition] — SELECT comes FIRST, before the conditions.',
       entities: ['case', 'defect', 'run', 'result', 'plan', 'requirement'],
-      note: 'QQL is only available in Business and Enterprise Qase subscriptions',
+      note: 'QQL is only available in Teams and Enterprise Qase subscriptions',
       fieldNamesVary:
         'Field names are NOT uniform across entities — see the `entities` topic before writing ' +
         'a query. Most common failure: `created` exists on case/defect/plan/requirement but ' +


### PR DESCRIPTION
## What

The Startup and Business tiers were retired in favour of Teams. Three places in this repo still name Business as the plan that gates QQL:

| File | What it is |
|---|---|
| `src/operations-v2/qql/index.ts` | the `note` in the `qql_help` overview payload |
| `examples/qql-queries.md` (top) | the note under "What QQL can do" |
| `examples/qql-queries.md` (troubleshooting) | the plan-denial error entry |

All three now read **Teams and Enterprise**.

## Why the first one matters most

The `qql_help` note is not internal copy. It is returned to the MCP client and read back to end users when they ask what QQL is or why a query failed, so a deprecated tier name reaches customers directly.

It has also already propagated: the `qase-quality-supervisor` plugin repeats "Business or Enterprise" in its README, QUICKSTART and SECURITY (fixed in a companion PR), and from there it reached a published Qase help-center article, which has since been corrected.

## Two deliberate omissions

- **`CHANGELOG.md` is untouched.** Line 374 records that QQL required a Business subscription at the time that version shipped. That was true then; a changelog is a historical record, not current documentation.
- **The troubleshooting string is a paraphrase, not a verified backend error.** `"QQL search requires Business or Enterprise subscription"` appears nowhere in `src/`, so it looks like an approximation of what the API returns rather than a copy of it. I renamed the tier to keep it consistent, but if someone can confirm the exact string the API emits, that entry should quote it verbatim instead. Same for whether the backend itself still says "Business" anywhere, which is outside this repo.

## Testing

String-literal changes only, in one `qql_help` payload and one examples doc. No test asserts on the old wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)