### PR TITLE
test: stop the attachment stream race from failing unrelated suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`GROUP BY status` returned rows nothing could tell apart.** The documented example `SELECT (COUNT(id)) ... GROUP BY status` comes back as bare `{count_id}` rows with no status key, because a grouped field is only returned when it is also in `SELECT`. The example now reads `SELECT (status, COUNT(id))`, and the pitfall is spelled out.
 - **Untested results carry no execution data**, which `entities.result` did not mention: `comment`, `stacktrace`, `steps` and `end_time` come back empty and `timeSpent` is 0. `timeSpent` aggregates skip them, but `COUNT` does not — so the same query can report more rows without moving its averages.
 
+- **The attachment tests could fail the release build on an unrelated suite.** A path input becomes `createReadStream(path)`, which opens the file on a later tick; tests that only assert on `.path` never read the stream, so the open landed after `afterAll` had removed the scratch directory. With no `error` listener on the stream, that `ENOENT` surfaced as an unhandled failure attributed to whichever suite the worker was running by then — `integration-headers.test.ts`, which touches no files — and the open handle kept the worker alive past the end of the run. It only reproduced when Jest had few workers, which is exactly the CI runner, and it blocked the 2.2.3 publish job three runs in a row.
+
 ## [2.2.2]
 
 ### Added

--- a/src/operations-v2/write/attachments.test.ts
+++ b/src/operations-v2/write/attachments.test.ts
@@ -7,7 +7,7 @@
  * guessed base64-vs-path from the value, decoding plain text into noise.
  */
 
-import { describe, it, expect, beforeEach, afterAll } from '@jest/globals';
+import { describe, it, expect, beforeEach, afterEach, afterAll } from '@jest/globals';
 import { writeFileSync, mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -37,6 +37,25 @@ function uploadedBuffer(): Buffer {
 }
 
 const scratch = mkdtempSync(join(tmpdir(), 'qase-attach-'));
+
+// A path input becomes createReadStream(path), which opens the file on a later
+// tick. Tests that only assert on `.path` never read the stream, so the open
+// lands after the test finished and after afterAll's rmSync removed the file —
+// and with no 'error' listener on the stream, that ENOENT surfaced as an
+// unhandled failure against whichever suite the worker happened to be running
+// (integration-headers.test.ts, which touches no files at all), while the open
+// handle also kept the worker alive past the end of the run. destroy() alone
+// does not cancel a scheduled open, so the listener is what actually matters.
+afterEach(() => {
+  for (const [, files] of mockUpload.mock.calls) {
+    for (const file of files as Array<{ value: unknown }>) {
+      const stream = file.value as { destroy?: () => void; on?: (e: string, f: () => void) => void };
+      if (typeof stream?.destroy !== 'function') continue;
+      stream.on?.('error', () => {});
+      stream.destroy();
+    }
+  }
+});
 
 afterAll(() => rmSync(scratch, { recursive: true, force: true }));
 


### PR DESCRIPTION
## What broke

The `v2.2.3` publish job failed three runs in a row on Node 22, always like this:

```
FAIL src/client/integration-headers.test.ts
  ● integration marker on the wire › adds X-MCP-Integration-* ...
    ENOENT: no such file or directory, open '/tmp/qase-attach-iGtB83/local.txt'
```

`integration-headers.test.ts` performs no file operations at all. `local.txt` and `legacy.txt` belong to `attachments.test.ts`.

## Why

A path input becomes `createReadStream(path)` (`attachments.ts:64`), which opens the file on a later tick. The two tests that only assert on `.path` never read the stream, so the open lands after the test has finished — and after `afterAll` removed the scratch directory. With no `error` listener on the stream, that `ENOENT` becomes an unhandled failure, and Jest attributes it to whichever suite the worker is running by then. The same open handle is why the run also reports *"a worker process has failed to exit gracefully"*.

It needs few Jest workers to lose the race, which is exactly the CI runner — hence green locally, red on CI. `cd534f1` (the commit that introduced these tests, released as 2.2.2) failed the same way.

## Fix

`afterEach` attaches a no-op `error` listener to every stream handed to the mock and destroys it. The listener is the part that matters: `destroy()` does **not** cancel an already-scheduled open — I verified that directly, the `ENOENT` still arrives — it only releases the handle.

## Verification

Reproduced with `--maxWorkers=2` on Node 22: fails on the first run before this change, passes three for three after. Full suite 568 passed / 1 skipped, `tsc` and `eslint` clean.

Tests only — no production code touched. The CHANGELOG note goes under the existing `2.2.3` heading, since `v2.2.3` never published and the tag will be moved onto this commit.