### PR TITLE
feat: per-producer telemetry — attribute a call to the skill, command or agent behind it (v2.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0]
+
+### Added
+
+- **Per-producer attribution.** An integration built on top of this server can now say not only *who* it is but *which of its parts* made the call — a skill, a slash command, an agent — and where that call sits in the run. Two hidden arguments carry it: `_qase_integration` (`<name>/<version>`, the same marker the session header takes) and `_qase_producer` (`<producer>/<seq>/<entrypoint>`, entrypoint being one of `skill`, `command`, `agent`). They become three headers on the outbound Qase API request, beside the existing pair: `X-MCP-Integration-Producer`, `X-MCP-Integration-Seq`, `X-MCP-Integration-Entrypoint`.
+
+  The arguments travel in the call rather than in a header because a header cannot vary per call — the HTTP transport captures the integration marker once, when the session opens, and one session runs many producers in sequence. They are deliberately absent from every tool's input schema: they are not parameters, and no model should be asked to supply them. Both are stripped before the tool handler runs.
+
+  Call arguments now outrank the session header as a source of the integration marker, which in turn outranks `QASE_MCP_INTEGRATION` — a per-call claim is the more specific one. The session and env paths are untouched, only outranked.
+
+  A producer is never sent without an integration: alone it would say "some skill did this" without saying whose, and since the integration name is allowlisted (`ALLOWED_INTEGRATIONS`) while the producer is only shape-checked (`^[a-z0-9][a-z0-9-]{1,47}$`), the integration is what keeps an arbitrary client out of the analytics dimension. Producers are validated by shape rather than by list on purpose, so a new plugin skill does not need a server release to be counted; cardinality is bounded by that pattern, by the `seq` cap of 500, and by the integration allowlist. Anything malformed, oversized or unknown is dropped silently and the API call still succeeds.
+
+  Nothing is sent when neither argument is supplied, so clients that send neither are unaffected, and a client that sends them to an older server simply has them ignored.
+
 ## [2.2.3]
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qase/mcp-server",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "mcpName": "io.qase/mcp-server",
   "description": "Official MCP server for Qase Test Management Platform",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/qase-tms/qase-mcp-server",
     "source": "github"
   },
-  "version": "2.2.3",
+  "version": "2.3.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@qase/mcp-server",
-      "version": "2.2.3",
+      "version": "2.3.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -37,6 +37,8 @@ import FormData from 'form-data';
 import { requestTokenStorage, getEffectiveToken } from '../utils/auth-context.js';
 import { getServer } from '../utils/server-context.js';
 import { getIntegration } from '../utils/integration-context.js';
+import { getProducer } from '../utils/producer-context.js';
+import { buildIntegrationHeaders } from './producer-headers.js';
 import { parseIntegrationMarker } from '../utils/integration-marker.js';
 import { VERSION } from '../version.js';
 
@@ -138,15 +140,18 @@ class QaseApiClient {
     // X-MCP-Client-*: the same integration can run on any host, on either
     // deployment. Sourced per-request from integrationStorage, falling back to
     // QASE_MCP_INTEGRATION. Nothing is sent unless the marker is well-formed and
-    // allowlisted — see integration-marker.ts.
+    // allowlisted — see integration-marker.ts. The producer is a fourth axis
+    // under the integration, naming which part of it ran — a skill, a slash
+    // command, an agent — and it is never sent alone, since a producer without
+    // an integration attributes the call to nobody.
     this.axiosInstance.interceptors.request.use((req) => {
-      const integration = parseIntegrationMarker(getIntegration());
-      if (integration) {
+      const headers = buildIntegrationHeaders(
+        parseIntegrationMarker(getIntegration()),
+        getProducer(),
+      );
+      if (Object.keys(headers).length > 0) {
         req.headers = req.headers ?? {};
-        req.headers['X-MCP-Integration-Name'] = integration.name;
-        if (integration.version) {
-          req.headers['X-MCP-Integration-Version'] = integration.version;
-        }
+        Object.assign(req.headers, headers);
       }
       return req;
     });

--- a/src/client/producer-headers.test.ts
+++ b/src/client/producer-headers.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from '@jest/globals';
+import { buildIntegrationHeaders } from './producer-headers.js';
+
+describe('buildIntegrationHeaders', () => {
+  it('sends nothing without an integration', () => {
+    expect(
+      buildIntegrationHeaders(undefined, { producer: 'a-skill', seq: 1, entrypoint: 'skill' }),
+    ).toEqual({});
+  });
+
+  it('sends the integration alone when there is no producer', () => {
+    expect(
+      buildIntegrationHeaders({ name: 'quality-supervisor', version: '0.4.0' }, undefined),
+    ).toEqual({
+      'X-MCP-Integration-Name': 'quality-supervisor',
+      'X-MCP-Integration-Version': '0.4.0',
+    });
+  });
+
+  it('sends all five when both are present', () => {
+    expect(
+      buildIntegrationHeaders(
+        { name: 'quality-supervisor', version: '0.4.0' },
+        { producer: 'analyzing-test-coverage', seq: 3, entrypoint: 'skill' },
+      ),
+    ).toEqual({
+      'X-MCP-Integration-Name': 'quality-supervisor',
+      'X-MCP-Integration-Version': '0.4.0',
+      'X-MCP-Integration-Producer': 'analyzing-test-coverage',
+      'X-MCP-Integration-Seq': '3',
+      'X-MCP-Integration-Entrypoint': 'skill',
+    });
+  });
+
+  it('omits the version when the integration has none', () => {
+    expect(buildIntegrationHeaders({ name: 'quality-supervisor' }, undefined)).toEqual({
+      'X-MCP-Integration-Name': 'quality-supervisor',
+    });
+  });
+});

--- a/src/client/producer-headers.ts
+++ b/src/client/producer-headers.ts
@@ -1,0 +1,31 @@
+import type { IntegrationMarker } from '../utils/integration-marker.js';
+import type { ProducerMarker } from '../utils/producer-marker.js';
+
+/**
+ * The attribution headers for one outbound Qase API request.
+ *
+ * A producer is never sent without an integration. A producer alone says "some
+ * skill did this" without saying whose skill, which is not an attribution; and
+ * because the integration name is allowlisted while the producer is only
+ * shape-checked, the integration is what keeps an arbitrary client out of the
+ * analytics dimension.
+ */
+export function buildIntegrationHeaders(
+  integration: IntegrationMarker | undefined,
+  producer: ProducerMarker | undefined,
+): Record<string, string> {
+  if (!integration) return {};
+
+  const headers: Record<string, string> = {
+    'X-MCP-Integration-Name': integration.name,
+  };
+  if (integration.version) {
+    headers['X-MCP-Integration-Version'] = integration.version;
+  }
+  if (producer) {
+    headers['X-MCP-Integration-Producer'] = producer.producer;
+    headers['X-MCP-Integration-Seq'] = String(producer.seq);
+    headers['X-MCP-Integration-Entrypoint'] = producer.entrypoint;
+  }
+  return headers;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,10 @@ import { formatApiError, ToolExecutionError } from './utils/errors.js';
 import { compactResponse } from './utils/response-shape.js';
 import { isRichResult } from './utils/rich-response.js';
 import { serverStorage, confirmDestructiveAction } from './utils/server-context.js';
+import { extractCallMarkers } from './utils/call-markers.js';
+import { parseProducerMarker } from './utils/producer-marker.js';
+import { producerStorage } from './utils/producer-context.js';
+import { callIntegrationStorage } from './utils/integration-context.js';
 import { setupSSETransport } from './transports/sse.js';
 import { setupStreamableHttpTransport } from './transports/streamableHttp.js';
 import { VERSION } from './version.js';
@@ -93,87 +97,102 @@ function createServer(): Server {
    */
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     return serverStorage.run(server, async () => {
-      const { name, arguments: args } = request.params;
+      const { name, arguments: rawArgs } = request.params;
+      // The two hidden attribution arguments never reach a tool handler — see
+      // call-markers.ts for why they travel as arguments rather than a header.
+      const markers = extractCallMarkers(rawArgs);
+      const args = markers.rest;
 
       console.error(`[Server] Executing tool: ${name}`);
 
-      // Get tool handler from registry
-      const handler = toolRegistry.getHandler(name);
-      if (!handler) {
-        throw new Error(`Unknown tool: ${name}. Use list_tools to see available tools.`);
-      }
-
-      // Elicitation: confirm destructive actions before execution
-      const toolDef = toolRegistry.getTool(name);
-      if (toolDef?.annotations?.destructiveHint === true) {
-        const confirmed = await confirmDestructiveAction(
-          name,
-          (args as Record<string, unknown>) || {},
-        );
-        if (!confirmed) {
-          return {
-            content: [{ type: 'text' as const, text: `Action "${name}" cancelled by user.` }],
-          };
-        }
-      }
-
-      try {
-        // Execute the tool handler with provided arguments
-        const result = await handler(args || {});
-
-        // Rich results: pass through pre-formatted content blocks directly
-        if (isRichResult(result)) {
-          return {
-            content: result.content,
-            ...(result.structuredContent && { structuredContent: result.structuredContent }),
-          };
+      const runCall = async () => {
+        // Get tool handler from registry
+        const handler = toolRegistry.getHandler(name);
+        if (!handler) {
+          throw new Error(`Unknown tool: ${name}. Use list_tools to see available tools.`);
         }
 
-        // Default: wrap in compact JSON text block
-        const compacted = compactResponse(result);
-        const hasOutputSchema = toolDef?.outputSchema !== undefined;
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(compacted),
-            },
-          ],
-          // SDK requires structuredContent when outputSchema is defined
-          ...(hasOutputSchema && { structuredContent: compacted as Record<string, unknown> }),
-        };
-      } catch (error) {
-        // Handle tool execution errors (expected failures like validation, API errors)
-        // These are returned with isError: true so the LLM can understand and recover
-        if (error instanceof ToolExecutionError) {
-          console.error(`[Server] Tool '${name}' execution error:`, error.message);
+        // Elicitation: confirm destructive actions before execution
+        const toolDef = toolRegistry.getTool(name);
+        if (toolDef?.annotations?.destructiveHint === true) {
+          const confirmed = await confirmDestructiveAction(
+            name,
+            (args as Record<string, unknown>) || {},
+          );
+          if (!confirmed) {
+            return {
+              content: [{ type: 'text' as const, text: `Action "${name}" cancelled by user.` }],
+            };
+          }
+        }
+
+        try {
+          // Execute the tool handler with provided arguments
+          const result = await handler(args || {});
+
+          // Rich results: pass through pre-formatted content blocks directly
+          if (isRichResult(result)) {
+            return {
+              content: result.content,
+              ...(result.structuredContent && { structuredContent: result.structuredContent }),
+            };
+          }
+
+          // Default: wrap in compact JSON text block
+          const compacted = compactResponse(result);
+          const hasOutputSchema = toolDef?.outputSchema !== undefined;
           return {
             content: [
               {
                 type: 'text',
-                text: error.toUserMessage(),
+                text: JSON.stringify(compacted),
+              },
+            ],
+            // SDK requires structuredContent when outputSchema is defined
+            ...(hasOutputSchema && { structuredContent: compacted as Record<string, unknown> }),
+          };
+        } catch (error) {
+          // Handle tool execution errors (expected failures like validation, API errors)
+          // These are returned with isError: true so the LLM can understand and recover
+          if (error instanceof ToolExecutionError) {
+            console.error(`[Server] Tool '${name}' execution error:`, error.message);
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: error.toUserMessage(),
+                },
+              ],
+              isError: true,
+            };
+          }
+
+          // Handle unexpected errors (protocol-level failures)
+          // Format error message using our error utilities
+          const errorMessage = formatApiError(error);
+          console.error(`[Server] Tool '${name}' unexpected error:`, errorMessage);
+
+          // Return as tool execution error with isError: true for better LLM recovery
+          return {
+            content: [
+              {
+                type: 'text',
+                text: errorMessage,
               },
             ],
             isError: true,
           };
         }
+      };
 
-        // Handle unexpected errors (protocol-level failures)
-        // Format error message using our error utilities
-        const errorMessage = formatApiError(error);
-        console.error(`[Server] Tool '${name}' unexpected error:`, errorMessage);
+      // Both scopes stay open for the whole call, so the outbound interceptor
+      // sees them however deep in the handler the API request is made.
+      const producer = parseProducerMarker(markers.producer);
+      const withProducer = producer ? () => producerStorage.run(producer, runCall) : runCall;
 
-        // Return as tool execution error with isError: true for better LLM recovery
-        return {
-          content: [
-            {
-              type: 'text',
-              text: errorMessage,
-            },
-          ],
-          isError: true,
-        };
-      }
+      return markers.integration
+        ? callIntegrationStorage.run(markers.integration, withProducer)
+        : withProducer();
     });
   });
 

--- a/src/utils/call-markers.test.ts
+++ b/src/utils/call-markers.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from '@jest/globals';
+import { extractCallMarkers } from './call-markers.js';
+
+describe('extractCallMarkers', () => {
+  it('removes both hidden fields from the arguments', () => {
+    const { rest } = extractCallMarkers({
+      entity: 'case',
+      id: 7,
+      _qase_integration: 'quality-supervisor/0.4.0',
+      _qase_producer: 'analyzing-test-coverage/1/skill',
+    });
+    expect(rest).toEqual({ entity: 'case', id: 7 });
+    expect(rest).not.toHaveProperty('_qase_integration');
+    expect(rest).not.toHaveProperty('_qase_producer');
+  });
+
+  it('returns both raw markers', () => {
+    const { integration, producer } = extractCallMarkers({
+      _qase_integration: 'quality-supervisor/0.4.0',
+      _qase_producer: 'quality-report/2/command',
+    });
+    expect(integration).toBe('quality-supervisor/0.4.0');
+    expect(producer).toBe('quality-report/2/command');
+  });
+
+  it('leaves ordinary arguments untouched when no markers are present', () => {
+    const args = { entity: 'case', id: 7 };
+    const { integration, producer, rest } = extractCallMarkers(args);
+    expect(integration).toBeUndefined();
+    expect(producer).toBeUndefined();
+    expect(rest).toEqual(args);
+  });
+
+  it('tolerates undefined and non-string markers', () => {
+    expect(extractCallMarkers(undefined).rest).toEqual({});
+    const { integration } = extractCallMarkers({ _qase_integration: 42 });
+    expect(integration).toBeUndefined();
+  });
+});

--- a/src/utils/call-markers.ts
+++ b/src/utils/call-markers.ts
@@ -1,0 +1,39 @@
+/**
+ * Hidden attribution arguments on a tools/call.
+ *
+ * A client cannot vary an HTTP header per call — the transport captures the
+ * integration marker once per MCP session — so an integration that wants to
+ * attribute individual calls has to put the marker in the arguments. These two
+ * fields are that channel. They are deliberately not declared in any tool's
+ * input schema: they are not parameters, and no model should be asked to supply
+ * them.
+ *
+ * They are stripped here, before the handler sees the arguments. qase_api was
+ * verified not to pass arguments through into a request body, but relying on no
+ * handler ever doing so is an assumption with no expiry date.
+ */
+
+export const INTEGRATION_ARG = '_qase_integration';
+export const PRODUCER_ARG = '_qase_producer';
+
+export interface CallMarkers {
+  integration?: string;
+  producer?: string;
+  rest: Record<string, unknown>;
+}
+
+export function extractCallMarkers(args: unknown): CallMarkers {
+  if (!args || typeof args !== 'object') return { rest: {} };
+
+  const {
+    [INTEGRATION_ARG]: integration,
+    [PRODUCER_ARG]: producer,
+    ...rest
+  } = args as Record<string, unknown>;
+
+  return {
+    integration: typeof integration === 'string' ? integration : undefined,
+    producer: typeof producer === 'string' ? producer : undefined,
+    rest,
+  };
+}

--- a/src/utils/integration-context.ts
+++ b/src/utils/integration-context.ts
@@ -14,15 +14,25 @@ import { AsyncLocalStorage } from 'async_hooks';
 export const integrationStorage = new AsyncLocalStorage<string>();
 
 /**
- * Read the marker for the current async context: request-scoped value first,
- * then the QASE_MCP_INTEGRATION env var (the stdio path, where there is no
- * request to carry a header).
+ * Per-call integration marker, supplied in the call arguments rather than a
+ * header. Takes priority over the session-scoped value: a per-call claim is more
+ * specific than one captured when the session opened.
+ */
+export const callIntegrationStorage = new AsyncLocalStorage<string>();
+
+/**
+ * Read the marker for the current async context: the per-call value first, then
+ * the request-scoped one, then the QASE_MCP_INTEGRATION env var (the stdio path,
+ * where there is no request to carry a header).
  *
- * Returns undefined when neither is set — the common case, and the one that must
+ * Returns undefined when none is set — the common case, and the one that must
  * leave the outbound request untouched. The value is unvalidated; callers pass it
  * through parseIntegrationMarker().
  */
 export function getIntegration(): string | undefined {
+  const callIntegration = callIntegrationStorage.getStore();
+  if (callIntegration) return callIntegration;
+
   const requestIntegration = integrationStorage.getStore();
   if (requestIntegration) return requestIntegration;
   return process.env.QASE_MCP_INTEGRATION?.trim() || undefined;

--- a/src/utils/producer-context.ts
+++ b/src/utils/producer-context.ts
@@ -1,0 +1,15 @@
+import { AsyncLocalStorage } from 'async_hooks';
+import type { ProducerMarker } from './producer-marker.js';
+
+/**
+ * Per-call producer storage.
+ *
+ * Per *call*, not per request or per session: one MCP session runs many
+ * producers in sequence, which is the whole point of the axis. Opened by the
+ * CallTool handler and read by the outbound interceptor.
+ */
+export const producerStorage = new AsyncLocalStorage<ProducerMarker>();
+
+export function getProducer(): ProducerMarker | undefined {
+  return producerStorage.getStore();
+}

--- a/src/utils/producer-marker.test.ts
+++ b/src/utils/producer-marker.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from '@jest/globals';
+import { parseProducerMarker, MAX_SEQ } from './producer-marker.js';
+
+describe('parseProducerMarker', () => {
+  it('accepts <producer>/<seq>/<entrypoint>', () => {
+    expect(parseProducerMarker('analyzing-test-coverage/3/skill')).toEqual({
+      producer: 'analyzing-test-coverage',
+      seq: 3,
+      entrypoint: 'skill',
+    });
+  });
+
+  it('accepts every entrypoint', () => {
+    expect(parseProducerMarker('quality-report/1/command')?.entrypoint).toBe('command');
+    expect(parseProducerMarker('quality-supervisor/1/agent')?.entrypoint).toBe('agent');
+  });
+
+  it('lowercases the producer', () => {
+    expect(parseProducerMarker('Analyzing-Test-Coverage/1/skill')?.producer).toBe(
+      'analyzing-test-coverage',
+    );
+  });
+
+  it('caps seq rather than rejecting a long run', () => {
+    expect(parseProducerMarker(`a-skill/99999/skill`)?.seq).toBe(MAX_SEQ);
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['empty', ''],
+    ['no entrypoint', 'a-skill/1'],
+    ['unknown entrypoint', 'a-skill/1/hacking'],
+    ['non-numeric seq', 'a-skill/one/skill'],
+    ['zero seq', 'a-skill/0/skill'],
+    ['negative seq', 'a-skill/-1/skill'],
+    ['producer starting with a dash', '-skill/1/skill'],
+    ['producer with underscores', 'a_skill/1/skill'],
+    ['producer with a space', 'a skill/1/skill'],
+    ['producer too long', `${'a'.repeat(49)}/1/skill`],
+    ['single character producer', 'a/1/skill'],
+  ])('rejects %s', (_label, input) => {
+    expect(parseProducerMarker(input as string | undefined | null)).toBeUndefined();
+  });
+
+  it('never throws on hostile input', () => {
+    expect(() => parseProducerMarker('/'.repeat(10_000))).not.toThrow();
+    expect(parseProducerMarker('/'.repeat(10_000))).toBeUndefined();
+  });
+});

--- a/src/utils/producer-marker.ts
+++ b/src/utils/producer-marker.ts
@@ -1,0 +1,63 @@
+/**
+ * Producer Marker
+ *
+ * Which *part* of an integration produced this call — a skill, a slash command,
+ * or an agent. A fourth axis under the integration marker (see
+ * integration-marker.ts), answering "what did they run" where that one answers
+ * "what is driving the server".
+ *
+ * Unlike integrations, producers are NOT allowlisted. An integration is a
+ * product and its name is a deliberate, reviewed addition; a producer is a part
+ * of one, and new parts appear whenever that product ships a feature. Requiring
+ * a server release before a new skill could be counted would guarantee the
+ * metric lags the thing it measures. Cardinality is instead bounded by the
+ * pattern below, by the seq cap, and by the fact that nothing is forwarded
+ * unless the integration name itself passed the allowlist.
+ */
+
+/** How the user reached the producer. */
+export type Entrypoint = 'skill' | 'command' | 'agent';
+
+const ENTRYPOINTS: readonly string[] = ['skill', 'command', 'agent'];
+
+/** Lowercase, dash-separated, 2-48 characters. Deliberately narrow. */
+const PRODUCER_PATTERN = /^[a-z0-9][a-z0-9-]{1,47}$/;
+
+/** Longest input we will look at; longer is truncated, then validated. */
+const MAX_FIELD_LENGTH = 128;
+
+/** Calls beyond this in one run all report the cap, bounding cardinality. */
+export const MAX_SEQ = 500;
+
+export interface ProducerMarker {
+  producer: string;
+  /** 1-based index of this call within its run; MAX_SEQ for anything beyond. */
+  seq: number;
+  entrypoint: Entrypoint;
+}
+
+/**
+ * Parse a `<producer>/<seq>/<entrypoint>` marker.
+ *
+ * Best-effort and silent, exactly like parseIntegrationMarker: anything
+ * malformed yields undefined rather than an error, so a bad marker can never
+ * fail the API call it was attached to.
+ */
+export function parseProducerMarker(raw: string | undefined | null): ProducerMarker | undefined {
+  const trimmed = raw?.trim().slice(0, MAX_FIELD_LENGTH);
+  if (!trimmed) return undefined;
+
+  const parts = trimmed.split('/');
+  if (parts.length !== 3) return undefined;
+
+  const producer = parts[0].trim().toLowerCase();
+  if (!PRODUCER_PATTERN.test(producer)) return undefined;
+
+  const entrypoint = parts[2].trim().toLowerCase();
+  if (!ENTRYPOINTS.includes(entrypoint)) return undefined;
+
+  const seq = Number(parts[1].trim());
+  if (!Number.isInteger(seq) || seq < 1) return undefined;
+
+  return { producer, seq: Math.min(seq, MAX_SEQ), entrypoint: entrypoint as Entrypoint };
+}


### PR DESCRIPTION
## What this adds

An integration built on top of this server could already say *who* it is (`X-MCP-Integration-Name` / `-Version`). It could not say **which of its parts** made a given call. This adds that: the skill, slash command or agent behind the call, and where the call sits in that run.

Two hidden arguments carry it on `tools/call`:

| Argument | Format | Example |
|---|---|---|
| `_qase_integration` | `<name>/<version>` | `quality-supervisor/0.4.0` |
| `_qase_producer` | `<producer>/<seq>/<entrypoint>` | `analyzing-test-coverage/3/skill` |

They become three headers beside the existing pair: `X-MCP-Integration-Producer`, `-Seq`, `-Entrypoint`.

## Why arguments and not a header

A header cannot vary per call. The streamable-http transport captures the integration marker **once**, when the session opens, into `sessionIntegrations` — and one session runs many producers in sequence, which is the entire point of the new axis. So an integration that wants per-call attribution has to put the marker in the call.

Both fields are deliberately absent from every tool's input schema: they are not parameters, and no model should be asked to supply them. They are stripped in the CallTool handler before any tool handler sees the arguments. `qase_api` was verified not to pass arguments through into a request body, but relying on no handler ever doing so is an assumption with no expiry date — so the strip is unconditional, and there is a test for it.

Call arguments now outrank the session header in `getIntegration()`, which still outranks `QASE_MCP_INTEGRATION`. A per-call claim is the more specific one. The session and env paths are untouched, only outranked.

## Two rules that bound the blast radius

**A producer is never sent without an integration.** Alone it would say "some skill did this" without saying whose, which is not an attribution. It matters more than it reads: the integration name is allowlisted (`ALLOWED_INTEGRATIONS`) while the producer is only shape-checked, so the integration is what keeps an arbitrary client out of the analytics dimension.

**Producers are validated by shape, not by membership** — `^[a-z0-9][a-z0-9-]{1,47}$`, not a list of skill names. An allowlist here would put a server release between a new plugin skill and its first data point, guaranteeing the metric lags the thing it measures. Cardinality is instead held by that pattern, by the `seq` cap of 500, and by the integration allowlist that gates everything.

Nothing throws. A malformed, oversized or unknown marker yields `undefined` and the API call proceeds unmarked — the contract `integration-marker.ts` already states, applied verbatim.

## Compatibility

Backwards compatible in both directions. A client that sends neither argument is byte-for-byte unaffected on the wire; a client that sends them to an older server has them ignored. The monolith side is already in production, so the receiving end is ready.

## Verification

`npm test && npm run lint && npm run build` — 594 passed, 1 skipped, 0 failed; lint 0 errors. The existing `streamableHttp.integration-marker.test.ts` stays green: the session path is unchanged, only outranked.

End to end against a live server with `QASE_API_DOMAIN` pointed at a mock API that logs what it receives:

| Sent on the call | Reached the API |
|---|---|
| integration + producer `.../1/skill` | all five headers, `Seq: 1` |
| integration + producer `.../2/command` | all five, `Seq: 2` — increments across the run |
| integration only | `Name` + `Version` only |
| producer without an integration | nothing |
| non-allowlisted integration + valid producer | nothing |
| valid integration + malformed producer | `Name` + `Version` only |
| `seq=99999` | `Seq: 500` — the cap holds |
| `POST` carrying both markers | body `{"title":"Demo","code":"DEMO"}` — no leak |

## Note for review

The plan this implements says the repo is on v2.2.2; `main` had already moved to 2.2.3, so 2.3.0 is bumped from there. The plan also missed that the version is duplicated in `server.json` (root and `packages[0]`) — the pre-commit hook caught it, and that file is in the third commit.
